### PR TITLE
feat: add the ability to override config with env var

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.18"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
 
 [[package]]
 name = "android-tzdata"
@@ -174,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.17"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a1e53f0f5d86382dafe1cf314783b2044280f406e7e1506368220ad11b1338"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
@@ -223,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.91"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
+checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 dependencies = [
  "backtrace",
 ]
@@ -457,7 +457,7 @@ dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
  "syn 1.0.109",
- "synstructure",
+ "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -515,7 +515,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -526,7 +526,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -584,7 +584,7 @@ dependencies = [
 [[package]]
 name = "atoma-sui"
 version = "0.1.0"
-source = "git+https://github.com/atoma-network/atoma-node.git?branch=temp#a7c5f5824a806f513600c09bdc56ab6db12abbf3"
+source = "git+https://github.com/atoma-network/atoma-node.git?branch=main#b571a84791f5fa51428223cfb98e90720fd69ec3"
 dependencies = [
  "anyhow",
  "config",
@@ -684,7 +684,7 @@ checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1109,9 +1109,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.31"
+version = "1.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
+checksum = "40545c26d092346d8a8dab71ee48e7685a7a9cba76e634790c215b41a4a7b4cf"
 dependencies = [
  "jobserver",
  "libc",
@@ -1214,7 +1214,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1291,7 +1291,7 @@ dependencies = [
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "fastcrypto",
  "mysten-network",
@@ -1514,9 +1514,9 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
 dependencies = [
  "csv-core",
  "itoa",
@@ -1600,7 +1600,7 @@ dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
  "strsim 0.11.1",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1622,7 +1622,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1750,7 +1750,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1760,7 +1760,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1773,7 +1773,7 @@ dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
  "rustc_version",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1873,7 +1873,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1912,7 +1912,7 @@ dependencies = [
  "optfield",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2051,7 +2051,7 @@ dependencies = [
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "serde_yaml",
 ]
@@ -2065,7 +2065,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2252,9 +2252,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 
 [[package]]
 name = "ff"
@@ -2444,7 +2444,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2645,9 +2645,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
 
 [[package]]
 name = "hashlink"
@@ -2922,9 +2922,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-timeout"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
  "hyper 1.5.0",
  "hyper-util",
@@ -2992,6 +2992,124 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2 1.0.89",
+ "quote 1.0.37",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2999,12 +3117,23 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.5.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -3074,7 +3203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.1",
  "serde",
 ]
 
@@ -3402,9 +3531,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
 
 [[package]]
 name = "libm"
@@ -3444,6 +3573,12 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "litemap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 
 [[package]]
 name = "lock_api"
@@ -3606,13 +3741,13 @@ checksum = "a7ce64b975ed4f123575d11afd9491f2e37bbd5813fbfbc0f09ae1fbddea74e0"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "move-binary-format",
  "move-bytecode-verifier-meter",
@@ -3621,12 +3756,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -3640,12 +3775,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3661,7 +3796,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "anyhow",
  "indexmap 2.6.0",
@@ -3674,7 +3809,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -3689,7 +3824,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -3699,7 +3834,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3718,7 +3853,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3739,6 +3874,7 @@ dependencies = [
  "move-symbol-pool",
  "once_cell",
  "petgraph",
+ "rayon",
  "regex",
  "serde",
  "serde_json",
@@ -3751,7 +3887,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3775,13 +3911,14 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "anyhow",
  "bcs",
  "clap",
  "codespan",
  "colored",
+ "indexmap 2.6.0",
  "move-abstract-interpreter",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -3795,7 +3932,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3815,7 +3952,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -3833,7 +3970,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "anyhow",
  "hex",
@@ -3846,7 +3983,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -3859,17 +3996,17 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "enum-compat-util",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "once_cell",
  "phf",
@@ -3879,7 +4016,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -3888,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "move-vm-config",
  "once_cell",
@@ -3900,7 +4037,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -3914,7 +4051,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -3987,13 +4124,13 @@ dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
  "syn 1.0.109",
- "synstructure",
+ "synstructure 0.12.6",
 ]
 
 [[package]]
 name = "mysten-metrics"
 version = "0.7.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "async-trait",
  "axum",
@@ -4014,7 +4151,7 @@ dependencies = [
 [[package]]
 name = "mysten-network"
 version = "0.2.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "anemo",
  "async-stream",
@@ -4043,7 +4180,7 @@ dependencies = [
 [[package]]
 name = "mysten-util-mem"
 version = "0.11.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "cfg-if",
  "ed25519-consensus",
@@ -4062,11 +4199,11 @@ dependencies = [
 [[package]]
 name = "mysten-util-mem-derive"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "proc-macro2 1.0.89",
  "syn 1.0.109",
- "synstructure",
+ "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -4081,7 +4218,7 @@ dependencies = [
 [[package]]
 name = "narwhal-config"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "fastcrypto",
  "match_opt",
@@ -4098,7 +4235,7 @@ dependencies = [
 [[package]]
 name = "narwhal-crypto"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "bcs",
  "fastcrypto",
@@ -4305,7 +4442,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4431,7 +4568,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4460,7 +4597,7 @@ checksum = "fa59f025cde9c698fcb4fcb3533db4621795374065bee908215263488f2d2a1d"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4500,7 +4637,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4718,7 +4855,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4772,7 +4909,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4801,7 +4938,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4989,7 +5126,7 @@ dependencies = [
 [[package]]
 name = "prometheus-closure-metric"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -5047,7 +5184,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5122,9 +5259,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e346e016eacfff12233c243718197ca12f148c84e1e84268a896699b41c71780"
+checksum = "7d5a626c6807713b15cac82a6acaccd6043c9a5408c24baae07611fec3f243da"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -5264,7 +5401,7 @@ checksum = "a25d631e41bfb5fdcde1d4e2215f62f7f0afa3ff11e26563765bd6ea1d229aeb"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5304,7 +5441,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5580,9 +5717,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.38"
+version = "0.38.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa260229e6538e52293eeb577aabd09945a09d6d9cc0fc550ed7529056c2e32a"
+checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -5742,7 +5879,7 @@ dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
  "serde_derive_internals",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5823,9 +5960,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
+checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5894,7 +6031,7 @@ checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5905,7 +6042,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5939,7 +6076,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5990,7 +6127,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6075,7 +6212,7 @@ dependencies = [
 [[package]]
 name = "shared-crypto"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "bcs",
  "eyre",
@@ -6348,7 +6485,7 @@ dependencies = [
  "quote 1.0.37",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6371,7 +6508,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.85",
+ "syn 2.0.87",
  "tempfile",
  "tokio",
  "url",
@@ -6481,6 +6618,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "stacker"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6563,7 +6706,7 @@ dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
  "rustversion",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6581,7 +6724,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 [[package]]
 name = "sui-config"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "anemo",
  "anyhow",
@@ -6611,7 +6754,7 @@ dependencies = [
 [[package]]
 name = "sui-enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "serde_yaml",
 ]
@@ -6619,7 +6762,7 @@ dependencies = [
 [[package]]
 name = "sui-json"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6636,7 +6779,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc-api"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -6656,7 +6799,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc-types"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6686,7 +6829,7 @@ dependencies = [
 [[package]]
 name = "sui-keys"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "anyhow",
  "bip32",
@@ -6705,7 +6848,7 @@ dependencies = [
 [[package]]
 name = "sui-macros"
 version = "0.7.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "futures",
  "once_cell",
@@ -6715,8 +6858,8 @@ dependencies = [
 
 [[package]]
 name = "sui-open-rpc"
-version = "1.37.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+version = "1.38.0"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "bcs",
  "schemars",
@@ -6728,7 +6871,7 @@ dependencies = [
 [[package]]
 name = "sui-open-rpc-macros"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -6741,7 +6884,7 @@ dependencies = [
 [[package]]
 name = "sui-package-resolver"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "async-trait",
  "bcs",
@@ -6760,19 +6903,19 @@ dependencies = [
 [[package]]
 name = "sui-proc-macros"
 version = "0.7.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "msim-macros",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
  "sui-enum-compat-util",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "sui-protocol-config"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "clap",
  "insta",
@@ -6788,7 +6931,7 @@ dependencies = [
 [[package]]
 name = "sui-protocol-config-macros"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
@@ -6798,7 +6941,7 @@ dependencies = [
 [[package]]
 name = "sui-rest-api"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6832,8 +6975,8 @@ dependencies = [
 
 [[package]]
 name = "sui-sdk"
-version = "1.37.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+version = "1.38.0"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6886,7 +7029,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-builder"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6903,7 +7046,7 @@ dependencies = [
 [[package]]
 name = "sui-types"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "anemo",
  "anyhow",
@@ -6994,9 +7137,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.85"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
@@ -7028,6 +7171,17 @@ dependencies = [
  "quote 1.0.37",
  "syn 1.0.109",
  "unicode-xid 0.2.6",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2 1.0.89",
+ "quote 1.0.37",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -7083,9 +7237,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -7115,22 +7269,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.65"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.65"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -7212,6 +7366,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7260,9 +7424,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.41.0"
+version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
+checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
 dependencies = [
  "backtrace",
  "bytes",
@@ -7284,7 +7448,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -7555,7 +7719,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -7649,7 +7813,7 @@ dependencies = [
 [[package]]
 name = "typed-store-error"
 version = "0.4.0"
-source = "git+https://github.com/mystenlabs/sui#c92dd1b4f16074ced8c1fe5c56a10e675f68bbe6"
+source = "git+https://github.com/mystenlabs/sui#59f747cd02ff172fc20e90330225fb21ffc29604"
 dependencies = [
  "serde",
  "thiserror",
@@ -7680,7 +7844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a615d6c2764852a2e88a4f16e9ce1ea49bb776b5872956309e170d63a042a34f"
 dependencies = [
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -7834,9 +7998,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -7849,6 +8013,18 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -7972,7 +8148,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
@@ -8006,7 +8182,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8306,6 +8482,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
 name = "wyz"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8368,6 +8556,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoke"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+dependencies = [
+ "proc-macro2 1.0.89",
+ "quote 1.0.37",
+ "syn 2.0.87",
+ "synstructure 0.13.1",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8385,7 +8597,28 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+dependencies = [
+ "proc-macro2 1.0.89",
+ "quote 1.0.37",
+ "syn 2.0.87",
+ "synstructure 0.13.1",
 ]
 
 [[package]]
@@ -8405,7 +8638,29 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2 1.0.89",
+ "quote 1.0.37",
+ "syn 2.0.87",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 anyhow = "1.0.91"
 async-trait = "0.1.83"
 atoma-state = { path = "./atoma-state" }
-atoma-sui = { git = "https://github.com/atoma-network/atoma-node.git", package = "atoma-sui", branch = "temp" }
+atoma-sui = { git = "https://github.com/atoma-network/atoma-node.git", package = "atoma-sui", branch = "main" }
 axum = "0.7.7"
 blake2 = "0.10.6"
 clap = "4.5.20"

--- a/atoma-proxy/src/server/config.rs
+++ b/atoma-proxy/src/server/config.rs
@@ -60,12 +60,17 @@ impl AtomaServiceConfig {
     /// * The configuration format doesn't match the expected structure
     pub fn from_file_path<P: AsRef<Path>>(config_file_path: P) -> Self {
         let builder = Config::builder()
-            .add_source(File::with_name(config_file_path.as_ref().to_str().unwrap()));
+            .add_source(File::with_name(config_file_path.as_ref().to_str().unwrap()))
+            .add_source(
+                config::Environment::with_prefix("ATOMA_SERVICE")
+                    .keep_prefix(true)
+                    .separator("__"),
+            );
         let config = builder
             .build()
             .expect("Failed to generate atoma-service configuration file");
         config
-            .get::<Self>("atoma-service")
+            .get::<Self>("atoma_service")
             .expect("Failed to generate configuration instance")
     }
 }

--- a/atoma-state/src/config.rs
+++ b/atoma-state/src/config.rs
@@ -41,14 +41,20 @@ impl AtomaStateManagerConfig {
     /// let config = AtomaStateManagerConfig::from_file_path("path/to/config.toml");
     /// ```
     pub fn from_file_path<P: AsRef<Path>>(config_file_path: P) -> Self {
-        let builder = Config::builder().add_source(config::File::with_name(
-            config_file_path.as_ref().to_str().unwrap(),
-        ));
+        let builder = Config::builder()
+            .add_source(config::File::with_name(
+                config_file_path.as_ref().to_str().unwrap(),
+            ))
+            .add_source(
+                config::Environment::with_prefix("ATOMA_STATE")
+                    .keep_prefix(true)
+                    .separator("__"),
+            );
         let config = builder
             .build()
             .expect("Failed to generate atoma state configuration file");
         config
-            .get::<Self>("atoma-state")
+            .get::<Self>("atoma_state")
             .expect("Failed to generate configuration instance")
     }
 }

--- a/config.example.toml
+++ b/config.example.toml
@@ -10,7 +10,7 @@ sui_config_path = "~/.sui/sui_config/client.yaml"                               
 sui_keystore_path = "~/.sui/sui_config/sui.keystore"                                    # Path to the Sui keystore file, by default (on Linux, or MacOS)
 cursor_path = "./cursor.toml"
 
-[atoma-state]
+[atoma_state]
 # URL of the PostgreSQL database, it SHOULD be the same as the `ATOMA_STATE_DATABASE_URL` variable value in the .env file
 database_url = "postgresql://POSTGRES_USER:POSTGRES_PASSWORD@db:5432/POSTGRES_DB"
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,20 +1,27 @@
 [atoma-sui]
-http_rpc_node_addr = "https://fullnode.testnet.sui.io:443" # Current RPC node address for testnet
-atoma_db = "0x741693fc00dd8a46b6509c0c3dc6a095f325b8766e96f01ba73b668df218f859" # Current ATOMA DB object ID for testnet
+http_rpc_node_addr = "https://fullnode.testnet.sui.io:443"                              # Current RPC node address for testnet
+atoma_db = "0x741693fc00dd8a46b6509c0c3dc6a095f325b8766e96f01ba73b668df218f859"         # Current ATOMA DB object ID for testnet
 atoma_package_id = "0x0c4a52c2c74f9361deb1a1b8496698c7e25847f7ad9abfbd6f8c511e508c62a0" # Current ATOMA package ID for testnet
-toma_package_id = "0xd992f4c5bfb563a9a1ce503edb6bf518f20c52363ca4a18715f251eb2bdae3e0" # Current TOMA package ID for testnet
-request_timeout = { secs = 300, nanos = 0 } # Some reference value
-max_concurrent_requests = 10 # Some reference value
-limit = 100 # Some reference value
-node_small_ids = []  # List of node IDs under control
-task_small_ids = []  # List of task IDs under control
-sui_config_path = "~/.sui/sui_config/client.yaml" # Path to the Sui client configuration file, by default (on Linux, or MacOS)
-sui_keystore_path = "~/.sui/sui_config/sui.keystore" # Path to the Sui keystore file, by default (on Linux, or MacOS)
+toma_package_id = "0xd992f4c5bfb563a9a1ce503edb6bf518f20c52363ca4a18715f251eb2bdae3e0"  # Current TOMA package ID for testnet
+request_timeout = { secs = 300, nanos = 0 }                                             # Some reference value
+max_concurrent_requests = 10                                                            # Some reference value
+limit = 100                                                                             # Some reference value
+node_small_ids = []                                                                     # List of node IDs under control
+task_small_ids = []                                                                     # List of task IDs under control
+sui_config_path = "~/.sui/sui_config/client.yaml"                                       # Path to the Sui client configuration file, by default (on Linux, or MacOS)
+sui_keystore_path = "~/.sui/sui_config/sui.keystore"                                    # Path to the Sui keystore file, by default (on Linux, or MacOS)
 cursor_path = "."
 
 [atoma-state]
 # URL of the PostgreSQL database, it SHOULD be the same as the `ATOMA_STATE_DATABASE_URL` variable value in the .env file
 database_url = "postgresql://POSTGRES_USER:POSTGRES_PASSWORD@db:5432/POSTGRES_DB"
 
-[atoma-service]
+[atoma_service]
 service_bind_address = "0.0.0.0:8080" # Address to bind the service to
+password = "password" # Password for the service
+models = [
+  "meta-llama/Llama-3.2-3B-Instruct",
+  "meta-llama/Llama-3.2-1B-Instruct",
+] # Models supported by proxy
+revisions = ["main", "main"] # Revision of the above models
+hf_token = "<API_KEY>" # Hugging face api token, required if you want to access a gated model

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,4 +1,4 @@
-[atoma-sui]
+[atoma_sui]
 http_rpc_node_addr = "https://fullnode.testnet.sui.io:443"                              # Current RPC node address for testnet
 atoma_db = "0x741693fc00dd8a46b6509c0c3dc6a095f325b8766e96f01ba73b668df218f859"         # Current ATOMA DB object ID for testnet
 atoma_package_id = "0x0c4a52c2c74f9361deb1a1b8496698c7e25847f7ad9abfbd6f8c511e508c62a0" # Current ATOMA package ID for testnet
@@ -6,11 +6,9 @@ toma_package_id = "0xd992f4c5bfb563a9a1ce503edb6bf518f20c52363ca4a18715f251eb2bd
 request_timeout = { secs = 300, nanos = 0 }                                             # Some reference value
 max_concurrent_requests = 10                                                            # Some reference value
 limit = 100                                                                             # Some reference value
-node_small_ids = []                                                                     # List of node IDs under control
-task_small_ids = []                                                                     # List of task IDs under control
 sui_config_path = "~/.sui/sui_config/client.yaml"                                       # Path to the Sui client configuration file, by default (on Linux, or MacOS)
 sui_keystore_path = "~/.sui/sui_config/sui.keystore"                                    # Path to the Sui keystore file, by default (on Linux, or MacOS)
-cursor_path = "."
+cursor_path = "./cursor.toml"
 
 [atoma-state]
 # URL of the PostgreSQL database, it SHOULD be the same as the `ATOMA_STATE_DATABASE_URL` variable value in the .env file


### PR DESCRIPTION
The config of `atoma_service` and `atoma_state` can now be overwritten with env var.
E.g. `ATOMA_STATE__DATABASE_URL` will overwrite
```
[atoma_state]
database_url=""
```

`ATOMA_SERVICE__HF_TOKEN` will overwrite
```
[atoma_service]
hf_token = ""
```