### PR TITLE
feat: auth module, for jwt and api tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,11 +548,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoma-auth"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "atoma-state",
+ "blake2",
+ "chrono",
+ "config",
+ "flume",
+ "hex",
+ "jsonwebtoken",
+ "rand",
+ "serde",
+ "tokio",
+]
+
+[[package]]
 name = "atoma-proxy"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "atoma-auth",
  "atoma-proxy-service",
  "atoma-state",
  "atoma-sui",
@@ -3679,6 +3697,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
+dependencies = [
+ "base64 0.21.7",
+ "js-sys",
+ "pem",
+ "ring 0.17.8",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "k256"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6557,6 +6590,18 @@ name = "simple-server-timing-header"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e78919e05c9b8e123d435a4ad104b488ad1585631830e413830985c214086e"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+dependencies = [
+ "num-bigint 0.4.6",
+ "num-traits",
+ "thiserror 1.0.69",
+ "time",
+]
 
 [[package]]
 name = "siphasher"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,6 +562,7 @@ dependencies = [
  "rand",
  "serde",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,6 @@
 [workspace]
 resolver = "2"
-
-members = [
-  "atoma-proxy-service",
-  "atoma-proxy",
-  "atoma-state"
-]
+members = ["atoma-auth", "atoma-proxy-service", "atoma-proxy", "atoma-state"]
 
 [workspace.package]
 version = "0.1.0"
@@ -15,6 +10,7 @@ license = "Apache-2.0"
 [workspace.dependencies]
 anyhow = "1.0.91"
 async-trait = "0.1.83"
+atoma-auth = { path = "./atoma-auth" }
 atoma-proxy-service = { path = "./atoma-proxy-service" }
 atoma-state = { path = "./atoma-state" }
 atoma-sui = { git = "https://github.com/atoma-network/atoma-node.git", package = "atoma-sui", branch = "main" }
@@ -22,11 +18,13 @@ atoma-utils = { git = "https://github.com/atoma-network/atoma-node.git", package
 axum = "0.7.7"
 base64 = "0.22.1"
 blake2 = "0.10.6"
+chrono = "0.4.38"
 clap = "4.5.20"
 config = "0.14.1"
 flume = "0.11.1"
 futures = "0.3.31"
 hf-hub = "0.3.2"
+jsonwebtoken = "9.3.0"
 rand = "0.8.5"
 reqwest = "0.12.9"
 serde = "1.0.214"

--- a/atoma-auth/Cargo.toml
+++ b/atoma-auth/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "atoma-auth"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+atoma-state.workspace = true
+blake2.workspace = true
+chrono.workspace = true
+config.workspace = true
+flume.workspace = true
+hex = "0.4.3"
+jsonwebtoken.workspace = true
+rand = "0.8.5"
+serde = { workspace = true, features = ["derive"] }
+tokio.workspace = true

--- a/atoma-auth/Cargo.toml
+++ b/atoma-auth/Cargo.toml
@@ -16,3 +16,4 @@ jsonwebtoken.workspace = true
 rand = "0.8.5"
 serde = { workspace = true, features = ["derive"] }
 tokio.workspace = true
+tracing.workspace = true

--- a/atoma-auth/src/auth.rs
+++ b/atoma-auth/src/auth.rs
@@ -1,0 +1,375 @@
+use anyhow::Result;
+use atoma_state::types::AtomaAtomaStateManagerEvent;
+use blake2::{
+    digest::{consts::U32, generic_array::GenericArray},
+    Blake2b, Digest,
+};
+use chrono::{Duration, Utc};
+use flume::Sender;
+use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+use tokio::sync::oneshot;
+
+use crate::AtomaAuthConfig;
+
+const API_TOKEN_LENGTH: usize = 30;
+
+/// The claims struct for the JWT token
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Claims {
+    /// The user id from the DB
+    user_id: i64,
+    /// The expiration time of the token
+    exp: usize,
+    // If this token is a refresh token, this will be empty, in case of access token the refresh will be the hash of the refresh token
+    refresh_token_hash: Option<String>,
+}
+
+/// The Auth struct
+pub struct Auth {
+    /// The secret key for JWT authentication.
+    secret_key: String,
+    /// The access token lifetime in minutes.
+    access_token_lifetime: usize,
+    /// The refresh token lifetime in days.
+    refresh_token_lifetime: usize,
+    /// The sender for the state manager
+    state_manager_sender: Sender<AtomaAtomaStateManagerEvent>,
+}
+
+impl Auth {
+    /// Constructor
+    pub fn new(
+        config: AtomaAuthConfig,
+        state_manager_sender: Sender<AtomaAtomaStateManagerEvent>,
+    ) -> Self {
+        Self {
+            secret_key: config.secret_key,
+            access_token_lifetime: config.access_token_lifetime,
+            refresh_token_lifetime: config.refresh_token_lifetime,
+            state_manager_sender,
+        }
+    }
+
+    /// Generate a new refresh token
+    /// This method will generate a new refresh token for the user
+    ///
+    /// # Arguments
+    ///
+    /// * `user_id` - The user id for which the token is generated
+    ///
+    /// # Returns
+    ///
+    /// * `Result<String>` - The generated refresh token
+    ///
+    /// # Errors
+    ///
+    /// * If the token generation fails
+    fn generate_refresh_token(&self, user_id: i64) -> Result<String> {
+        let expiration = Utc::now() + Duration::days(self.refresh_token_lifetime as i64);
+        let claims = Claims {
+            user_id,
+            exp: expiration.timestamp() as usize,
+            refresh_token_hash: None,
+        };
+        let token = encode(
+            &Header::default(),
+            &claims,
+            &EncodingKey::from_secret(self.secret_key.as_ref()),
+        )?;
+        Ok(token)
+    }
+
+    /// This method validates a JWT token
+    /// The method will check if the token is expired and if the token is a refresh token or an access token
+    ///
+    /// # Arguments
+    ///
+    /// * `token` - The token to be validated
+    /// * `is_refresh` - If the token is a refresh token
+    ///
+    /// # Returns
+    ///
+    /// * `Result<Claims>` - The claims of the token
+    pub fn validate_token(&self, token: &str, is_refresh: bool) -> Result<Claims> {
+        let mut validation = Validation::default();
+        validation.validate_exp = true; // Enforce expiration validation
+
+        let token_data = decode::<Claims>(
+            token,
+            &DecodingKey::from_secret(self.secret_key.as_ref()),
+            &validation,
+        )?;
+
+        let claims = token_data.claims;
+        if claims.refresh_token_hash.is_none() != is_refresh {
+            Err(anyhow::anyhow!("Invalid token type"))
+        } else {
+            Ok(claims)
+        }
+    }
+
+    /// Check the validity of the refresh token
+    /// This method will check if the refresh token is valid (was not revoked) and it's not expired
+    ///
+    /// # Arguments
+    ///
+    /// * `refresh_token` - The refresh token to be checked
+    ///
+    /// # Returns
+    ///
+    /// * `Result<bool>` - If the refresh token is valid
+    async fn check_refresh_token_validity(
+        &self,
+        user_id: i64,
+        refresh_token_hash: &str,
+    ) -> Result<bool> {
+        let (result_sender, result_receiver) = oneshot::channel();
+        self.state_manager_sender
+            .send(AtomaAtomaStateManagerEvent::IsRefreshTokenValid {
+                user_id,
+                refresh_token_hash: refresh_token_hash.to_string(),
+                result_sender,
+            })?;
+        Ok(result_receiver.await??)
+    }
+
+    /// Generate a new access token from a refresh token
+    /// The refresh token is hashed and used in the access token, so we can check the validity of the access token based on the refresh token.
+    ///
+    /// # Arguments
+    ///
+    /// * `refresh_token` - The refresh token to be used to generate a new access token
+    ///
+    /// # Returns
+    ///
+    /// * `Result<String>` - The new access token
+    pub async fn generate_access_token(&self, refresh_token: &str) -> Result<String> {
+        let claims = self.validate_token(refresh_token, true)?;
+        let refresh_token_hash = self.hash_string(refresh_token);
+
+        if !self
+            .check_refresh_token_validity(claims.user_id, &refresh_token_hash)
+            .await?
+        {
+            return Err(anyhow::anyhow!("Refresh token is not valid"));
+        }
+        let expiration = Utc::now() + Duration::days(self.access_token_lifetime as i64);
+
+        let claims = Claims {
+            user_id: claims.user_id,
+            exp: expiration.timestamp() as usize,
+            refresh_token_hash: Some(refresh_token_hash),
+        };
+        let token = encode(
+            &Header::default(),
+            &claims,
+            &EncodingKey::from_secret(self.secret_key.as_ref()),
+        )?;
+        Ok(token)
+    }
+
+    /// Used for hashing password / refresh tokens
+    /// This method will hash the input using the Blake2b algorithm
+    ///
+    /// # Arguments
+    ///
+    /// * `password` - The password to be hashed
+    ///
+    /// # Returns
+    ///
+    /// * `String` - The hashed password
+    fn hash_string(&self, text: &str) -> String {
+        let mut hasher = Blake2b::new();
+        hasher.update(text);
+        let hash_result: GenericArray<u8, U32> = hasher.finalize();
+        hex::encode(hash_result)
+    }
+
+    /// Check the user password
+    /// This method will check if the user password is correct
+    /// The password is hashed and compared with the hashed password in the DB
+    /// If the password is correct, the method will generate a new refresh and access token
+    pub async fn check_user_password(
+        &self,
+        username: &str,
+        password: &str,
+    ) -> Result<(String, String)> {
+        let (result_sender, result_receiver) = oneshot::channel();
+        self.state_manager_sender.send(
+            AtomaAtomaStateManagerEvent::GetUserIdByUsernamePassword {
+                username: username.to_string(),
+                password: self.hash_string(password),
+                result_sender,
+            },
+        )?;
+        let user_id = result_receiver
+            .await??
+            .map(|user_id| user_id as u64)
+            .ok_or_else(|| anyhow::anyhow!("User not found"))?;
+        let refresh_token = self.generate_refresh_token(user_id as i64)?;
+        let access_token = self.generate_access_token(&refresh_token).await?;
+        Ok((refresh_token, access_token))
+    }
+
+    /// Generate a new API token
+    /// This method will generate a new API token for the user
+    /// The method will check if the access token and its corresponding refresh token is valid and store the new API token in the state manager
+    ///
+    /// # Arguments
+    ///
+    /// * `jwt` - The access token to be used to generate the API token
+    ///
+    /// # Returns
+    ///
+    /// * `Result<String>` - The generated API token
+    pub async fn generate_api_token(&self, jwt: &str) -> Result<String> {
+        let claims = self.validate_token(jwt, false)?;
+        if !self
+            .check_refresh_token_validity(
+                claims.user_id,
+                &claims
+                    .refresh_token_hash
+                    .expect("Access token should have refresh token hash"),
+            )
+            .await?
+        {
+            return Err(anyhow::anyhow!("Access token was revoked"));
+        }
+        let api_token: String = rand::thread_rng()
+            .sample_iter(&rand::distributions::Alphanumeric)
+            .take(API_TOKEN_LENGTH)
+            .map(char::from)
+            .collect();
+        self.state_manager_sender
+            .send(AtomaAtomaStateManagerEvent::StoreNewApiToken {
+                user_id: claims.user_id,
+                api_token: api_token.clone(),
+            })?;
+        Ok(api_token)
+    }
+}
+
+// TODO: Add more comprehensive tests, for now test the happy path only
+#[cfg(test)]
+mod test {
+    use atoma_state::types::AtomaAtomaStateManagerEvent;
+    use flume::Receiver;
+
+    use crate::AtomaAuthConfig;
+
+    use super::Auth;
+
+    fn setup_test() -> (Auth, Receiver<AtomaAtomaStateManagerEvent>) {
+        let config = AtomaAuthConfig::new("secret".to_string(), 1, 1);
+        let (state_manager_sender, state_manager_receiver) = flume::unbounded();
+        let auth = Auth::new(config, state_manager_sender);
+        (auth, state_manager_receiver)
+    }
+
+    #[tokio::test]
+    async fn test_access_token_regenerate() {
+        let (auth, receiver) = setup_test();
+        let user_id = 123;
+        let refresh_token = auth.generate_refresh_token(user_id).unwrap();
+        let refresh_token_hash = auth.hash_string(&refresh_token);
+        let mock_handle = tokio::task::spawn(async move {
+            let event = receiver.recv_async().await.unwrap();
+            match event {
+                AtomaAtomaStateManagerEvent::IsRefreshTokenValid {
+                    user_id: event_user_id,
+                    refresh_token_hash: event_refresh_token,
+                    result_sender,
+                } => {
+                    assert_eq!(event_user_id, user_id);
+                    assert_eq!(refresh_token_hash, event_refresh_token);
+                    result_sender.send(Ok(true)).unwrap();
+                }
+                _ => panic!("Unexpected event"),
+            }
+        });
+        let access_token = auth.generate_access_token(&refresh_token).await.unwrap();
+        let claims = auth.validate_token(&access_token, false).unwrap();
+        assert_eq!(claims.user_id, user_id);
+        assert!(claims.refresh_token_hash.is_some());
+        if tokio::time::timeout(std::time::Duration::from_secs(1), mock_handle)
+            .await
+            .is_err()
+        {
+            panic!("mock_handle did not finish within 1 second");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_token_flow() {
+        let user_id = 123;
+        let username = "user";
+        let password = "top_secret";
+        let (auth, receiver) = setup_test();
+        let hash_password = auth.hash_string(password);
+        let mock_handle = tokio::task::spawn(async move {
+            // First event is for the user to log in to get the tokens
+            let event = receiver.recv_async().await.unwrap();
+            match event {
+                AtomaAtomaStateManagerEvent::GetUserIdByUsernamePassword {
+                    username: event_username,
+                    password: event_password,
+                    result_sender,
+                } => {
+                    assert_eq!(username, event_username);
+                    assert_eq!(hash_password, event_password);
+                    result_sender.send(Ok(Some(user_id))).unwrap();
+                }
+                _ => panic!("Unexpected event"),
+            }
+            for _ in 0..2 {
+                // During the token generation, the refresh token is checked for validity
+                // 1) when the user logs in
+                // 2) when the api token is generated
+                let event = receiver.recv_async().await.unwrap();
+                match event {
+                    AtomaAtomaStateManagerEvent::IsRefreshTokenValid {
+                        user_id: event_user_id,
+                        refresh_token_hash: _refresh_token,
+                        result_sender,
+                    } => {
+                        assert_eq!(event_user_id, user_id);
+                        result_sender.send(Ok(true)).unwrap();
+                    }
+                    _ => panic!("Unexpected event"),
+                }
+            }
+            // Last event is for storing the new api token
+            let event = receiver.recv_async().await.unwrap();
+            match event {
+                AtomaAtomaStateManagerEvent::StoreNewApiToken {
+                    user_id: event_user_id,
+                    api_token: _api_token,
+                } => {
+                    assert_eq!(event_user_id, user_id);
+                    // assert_eq!(event_api_token, api_token);
+                }
+                _ => panic!("Unexpected event"),
+            }
+        });
+        let (refresh_token, access_token) =
+            auth.check_user_password(username, password).await.unwrap();
+        // Refresh token should not have refresh token hash
+        let claims = auth.validate_token(&refresh_token, true).unwrap();
+        assert_eq!(claims.user_id, user_id);
+        assert_eq!(claims.refresh_token_hash, None);
+        // Access token should have refresh token hash
+        let claims = auth.validate_token(&access_token, false).unwrap();
+        assert_eq!(claims.user_id, user_id);
+        assert!(claims.refresh_token_hash.is_some());
+        // Generate api token
+        let _api_token = auth.generate_api_token(&access_token).await.unwrap();
+        if tokio::time::timeout(std::time::Duration::from_secs(1), mock_handle)
+            .await
+            .is_err()
+        {
+            panic!("mock_handle did not finish within 1 second");
+        }
+    }
+}

--- a/atoma-auth/src/auth.rs
+++ b/atoma-auth/src/auth.rs
@@ -10,6 +10,7 @@ use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation}
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
+use tracing::instrument;
 
 use crate::AtomaAuthConfig;
 
@@ -66,6 +67,7 @@ impl Auth {
     /// # Errors
     ///
     /// * If the token generation fails
+    #[instrument(level = "trace", skip(self))]
     fn generate_refresh_token(&self, user_id: i64) -> Result<String> {
         let expiration = Utc::now() + Duration::days(self.refresh_token_lifetime as i64);
         let claims = Claims {
@@ -92,6 +94,7 @@ impl Auth {
     /// # Returns
     ///
     /// * `Result<Claims>` - The claims of the token
+    #[instrument(level = "trace", skip(self))]
     pub fn validate_token(&self, token: &str, is_refresh: bool) -> Result<Claims> {
         let mut validation = Validation::default();
         validation.validate_exp = true; // Enforce expiration validation
@@ -120,6 +123,7 @@ impl Auth {
     /// # Returns
     ///
     /// * `Result<bool>` - If the refresh token is valid
+    #[instrument(level = "trace", skip(self))]
     async fn check_refresh_token_validity(
         &self,
         user_id: i64,
@@ -145,6 +149,7 @@ impl Auth {
     /// # Returns
     ///
     /// * `Result<String>` - The new access token
+    #[instrument(level = "trace", skip(self))]
     pub async fn generate_access_token(&self, refresh_token: &str) -> Result<String> {
         let claims = self.validate_token(refresh_token, true)?;
         let refresh_token_hash = self.hash_string(refresh_token);
@@ -191,6 +196,7 @@ impl Auth {
     /// This method will check if the user password is correct
     /// The password is hashed and compared with the hashed password in the DB
     /// If the password is correct, the method will generate a new refresh and access token
+    #[instrument(level = "info", skip(self, password))]
     pub async fn check_user_password(
         &self,
         username: &str,
@@ -224,6 +230,7 @@ impl Auth {
     /// # Returns
     ///
     /// * `Result<String>` - The generated API token
+    #[instrument(level = "info", skip(self))]
     pub async fn generate_api_token(&self, jwt: &str) -> Result<String> {
         let claims = self.validate_token(jwt, false)?;
         if !self

--- a/atoma-auth/src/config.rs
+++ b/atoma-auth/src/config.rs
@@ -66,7 +66,7 @@ impl AtomaAuthConfig {
             .build()
             .expect("Failed to generate atoma state configuration file");
         config
-            .get::<Self>("atoma_state")
+            .get::<Self>("atoma_auth")
             .expect("Failed to generate configuration instance")
     }
 }

--- a/atoma-auth/src/config.rs
+++ b/atoma-auth/src/config.rs
@@ -1,0 +1,72 @@
+use config::Config;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+/// Configuration for Postgres database connection.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct AtomaAuthConfig {
+    /// The secret key for JWT authentication.
+    pub secret_key: String,
+    /// The access token lifetime in minutes.
+    pub access_token_lifetime: usize,
+    /// The refresh token lifetime in days.
+    pub refresh_token_lifetime: usize,
+}
+
+impl AtomaAuthConfig {
+    /// Constructor
+    pub fn new(
+        secret_key: String,
+        access_token_lifetime: usize,
+        refresh_token_lifetime: usize,
+    ) -> Self {
+        Self {
+            secret_key,
+            access_token_lifetime,
+            refresh_token_lifetime,
+        }
+    }
+
+    /// Creates a new `AtomaAuthConfig` instance from a configuration file.
+    ///
+    /// # Arguments
+    ///
+    /// * `config_file_path` - A path-like object representing the location of the configuration file.
+    ///
+    /// # Returns
+    ///
+    /// Returns a new `AtomaAuthConfig` instance populated with values from the configuration file.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if:
+    /// - The configuration file cannot be read or parsed.
+    /// - The "atoma-auth" section is missing from the configuration file.
+    /// - The required fields are missing or have invalid types in the configuration file.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use std::path::Path;
+    /// use atoma_node::atoma_state::AtomaAuthConfig;
+    ///
+    /// let config = AtomaAuthConfig::from_file_path("path/to/config.toml");
+    /// ```
+    pub fn from_file_path<P: AsRef<Path>>(config_file_path: P) -> Self {
+        let builder = Config::builder()
+            .add_source(config::File::with_name(
+                config_file_path.as_ref().to_str().unwrap(),
+            ))
+            .add_source(
+                config::Environment::with_prefix("ATOMA_AUTH")
+                    .keep_prefix(true)
+                    .separator("__"),
+            );
+        let config = builder
+            .build()
+            .expect("Failed to generate atoma state configuration file");
+        config
+            .get::<Self>("atoma_state")
+            .expect("Failed to generate configuration instance")
+    }
+}

--- a/atoma-auth/src/lib.rs
+++ b/atoma-auth/src/lib.rs
@@ -1,0 +1,5 @@
+mod auth;
+mod config;
+
+pub use auth::Auth;
+pub use config::AtomaAuthConfig;

--- a/atoma-proxy/Cargo.toml
+++ b/atoma-proxy/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
+atoma-auth.workspace = true
 atoma-proxy-service.workspace = true
 atoma-state.workspace = true
 atoma-sui.workspace = true

--- a/atoma-state/src/handlers.rs
+++ b/atoma-state/src/handlers.rs
@@ -898,8 +898,84 @@ pub(crate) async fn handle_state_manager_event(
                 .state
                 .get_selected_node_x25519_public_key(selected_node_id)
                 .await;
+            result_sender.send(public_key)
+        }
+        AtomaAtomaStateManagerEvent::GetUserIdByUsernamePassword {
+            username,
+            password,
+            result_sender,
+        } => {
+            let user_id = state_manager
+                .state
+                .get_user_id_by_username_password(&username, &password)
+                .await;
             result_sender
-                .send(public_key)
+                .send(user_id)
+                .map_err(|_| AtomaStateManagerError::ChannelSendError)?;
+        }
+        AtomaAtomaStateManagerEvent::IsRefreshTokenValid {
+            user_id,
+            refresh_token_hash,
+            result_sender,
+        } => {
+            let is_valid = state_manager
+                .state
+                .is_refresh_token_valid(user_id, &refresh_token_hash)
+                .await;
+            result_sender
+                .send(is_valid)
+                .map_err(|_| AtomaStateManagerError::ChannelSendError)?;
+        }
+        AtomaAtomaStateManagerEvent::StoresRefreshToken {
+            user_id,
+            refresh_token,
+        } => {
+            state_manager
+                .state
+                .store_refresh_token(user_id, &refresh_token)
+                .await?;
+        }
+        AtomaAtomaStateManagerEvent::RevokeRefreshToken {
+            user_id,
+            refresh_token,
+        } => {
+            state_manager
+                .state
+                .delete_refresh_token(user_id, &refresh_token)
+                .await?;
+        }
+        AtomaAtomaStateManagerEvent::IsApiTokenValid {
+            user_id,
+            api_token,
+            result_sender,
+        } => {
+            let is_valid = state_manager
+                .state
+                .is_api_token_valid(user_id, &api_token)
+                .await;
+            result_sender
+                .send(is_valid)
+                .map_err(|_| AtomaStateManagerError::ChannelSendError)?;
+        }
+        AtomaAtomaStateManagerEvent::StoreNewApiToken { user_id, api_token } => {
+            state_manager
+                .state
+                .store_api_token(user_id, &api_token)
+                .await?;
+        }
+        AtomaAtomaStateManagerEvent::RevokeApiToken { user_id, api_token } => {
+            state_manager
+                .state
+                .delete_api_token(user_id, &api_token)
+                .await?;
+        }
+        AtomaAtomaStateManagerEvent::GetApiTokensForUser {
+            user_id,
+            result_sender,
+        } => {
+            let api_tokens = state_manager.state.get_api_tokens_for_user(user_id).await;
+            result_sender
+                .send(api_tokens)
                 .map_err(|_| AtomaStateManagerError::ChannelSendError)?;
         }
     }

--- a/atoma-state/src/handlers.rs
+++ b/atoma-state/src/handlers.rs
@@ -898,7 +898,9 @@ pub(crate) async fn handle_state_manager_event(
                 .state
                 .get_selected_node_x25519_public_key(selected_node_id)
                 .await;
-            result_sender.send(public_key)
+            result_sender
+                .send(public_key)
+                .map_err(|_| AtomaStateManagerError::ChannelSendError)?;
         }
         AtomaAtomaStateManagerEvent::GetUserIdByUsernamePassword {
             username,

--- a/atoma-state/src/state_manager.rs
+++ b/atoma-state/src/state_manager.rs
@@ -3240,7 +3240,7 @@ pub(crate) mod queries {
     /// }
     /// ```
     #[instrument(level = "trace", skip_all)]
-    pub(crate) async fn create_nodes(db: &PgPool) -> Result<()> {
+    async fn create_nodes(db: &PgPool) -> Result<()> {
         sqlx::query(
             "CREATE TABLE IF NOT EXISTS nodes (
                 node_small_id BIGINT PRIMARY KEY,
@@ -3286,6 +3286,7 @@ pub(crate) mod queries {
     ///     Ok(())
     /// }
     /// ```
+    #[instrument(level = "trace", skip_all)]
     async fn create_nodes_performance(db: &PgPool) -> Result<()> {
         sqlx::query(
             "CREATE TABLE IF NOT EXISTS node_throughput_performance (
@@ -3372,7 +3373,8 @@ pub(crate) mod queries {
     ///     Ok(())
     /// }
     /// ```
-    pub(crate) async fn create_node_public_keys(db: &PgPool) -> Result<()> {
+    #[instrument(level = "trace", skip_all)]
+    async fn create_node_public_keys(db: &PgPool) -> Result<()> {
         sqlx::query(
             "CREATE TABLE IF NOT EXISTS node_public_keys (
                 node_small_id BIGINT PRIMARY KEY,
@@ -3420,6 +3422,7 @@ pub(crate) mod queries {
     ///     queries::create_table_users(pool).await?;
     ///     Ok(())
     /// }
+    #[instrument(level = "trace", skip_all)]
     async fn create_table_users(db: &PgPool) -> Result<()> {
         sqlx::query(
             "CREATE TABLE IF NOT EXISTS users (
@@ -3468,6 +3471,7 @@ pub(crate) mod queries {
     ///     Ok(())
     /// }
     /// ```
+    #[instrument(level = "trace", skip_all)]
     async fn create_table_refresh_tokens(db: &PgPool) -> Result<()> {
         sqlx::query(
             "CREATE TABLE IF NOT EXISTS refresh_tokens (
@@ -3517,6 +3521,7 @@ pub(crate) mod queries {
     ///     Ok(())
     /// }
     /// ```
+    #[instrument(level = "trace", skip_all)]
     async fn create_table_api_tokens(db: &PgPool) -> Result<()> {
         sqlx::query(
             "CREATE TABLE IF NOT EXISTS api_tokens (

--- a/atoma-state/src/state_manager.rs
+++ b/atoma-state/src/state_manager.rs
@@ -2670,6 +2670,7 @@ impl AtomaState {
     ///    state_manager.get_user_id_by_username_password(username, hashed_password).await
     /// }
     /// ```
+    #[instrument(level = "trace", skip(self))]
     pub async fn get_user_id_by_username_password(
         &self,
         username: &str,
@@ -2711,6 +2712,7 @@ impl AtomaState {
     ///   state_manager.is_refresh_token_valid(user_id, refresh_token_hash).await
     /// }
     /// ```
+    #[instrument(level = "trace", skip(self))]
     pub async fn is_refresh_token_valid(
         &self,
         user_id: i64,
@@ -2754,6 +2756,7 @@ impl AtomaState {
     ///    state_manager.store_refresh_token(user_id, refresh_token_hash).await
     /// }
     /// ```
+    #[instrument(level = "trace", skip(self))]
     pub async fn store_refresh_token(&self, user_id: i64, refresh_token_hash: &str) -> Result<()> {
         sqlx::query("INSERT INTO refresh_tokens (user_id, token_hash) VALUES ($1, $2)")
             .bind(user_id)
@@ -2790,6 +2793,7 @@ impl AtomaState {
     ///   state_manager.delete_refresh_token(user_id, refresh_token_hash).await
     /// }
     /// ```
+    #[instrument(level = "trace", skip(self))]
     pub async fn delete_refresh_token(&self, user_id: i64, refresh_token_hash: &str) -> Result<()> {
         sqlx::query("DELETE FROM refresh_tokens WHERE user_id = $1 AND token_hash = $2")
             .bind(user_id)
@@ -2826,6 +2830,7 @@ impl AtomaState {
     ///    state_manager.delete_api_token(user_id, api_token).await
     /// }
     /// ```
+    #[instrument(level = "trace", skip(self))]
     pub async fn delete_api_token(&self, user_id: i64, api_token: &str) -> Result<()> {
         sqlx::query("DELETE FROM api_tokens WHERE user_id = $1 AND token = $2")
             .bind(user_id)
@@ -2862,6 +2867,7 @@ impl AtomaState {
     ///    state_manager.is_api_token_valid(user_id, api_token).await
     /// }
     /// ```
+    #[instrument(level = "trace", skip(self))]
     pub async fn is_api_token_valid(&self, user_id: i64, api_token: &str) -> Result<bool> {
         let is_valid = sqlx::query(
             "SELECT EXISTS(SELECT 1 FROM api_tokens WHERE user_id = $1 AND token = $2)",
@@ -2901,6 +2907,7 @@ impl AtomaState {
     ///    state_manager.store_api_token(user_id, api_token).await
     /// }
     /// ```
+    #[instrument(level = "trace", skip(self))]
     pub async fn store_api_token(&self, user_id: i64, api_token: &str) -> Result<()> {
         sqlx::query("INSERT INTO api_tokens (user_id, token) VALUES ($1, $2)")
             .bind(user_id)
@@ -2936,6 +2943,7 @@ impl AtomaState {
     ///    state_manager.get_api_tokens_for_user(user_id).await
     /// }
     /// ```
+    #[instrument(level = "trace", skip(self))]
     pub async fn get_api_tokens_for_user(&self, user_id: i64) -> Result<Vec<String>> {
         let tokens = sqlx::query("SELECT token FROM api_tokens WHERE user_id = $1")
             .bind(user_id)

--- a/atoma-state/src/types.rs
+++ b/atoma-state/src/types.rs
@@ -287,4 +287,39 @@ pub enum AtomaAtomaStateManagerEvent {
         selected_node_id: i64,
         result_sender: oneshot::Sender<Result<Option<Vec<u8>>>>,
     },
+    GetUserIdByUsernamePassword {
+        username: String,
+        password: String,
+        result_sender: oneshot::Sender<Result<Option<i64>>>,
+    },
+    IsRefreshTokenValid {
+        user_id: i64,
+        refresh_token_hash: String,
+        result_sender: oneshot::Sender<Result<bool>>,
+    },
+    StoresRefreshToken {
+        user_id: i64,
+        refresh_token: String,
+    },
+    RevokeRefreshToken {
+        user_id: i64,
+        refresh_token: String,
+    },
+    IsApiTokenValid {
+        user_id: i64,
+        api_token: String,
+        result_sender: oneshot::Sender<Result<bool>>,
+    },
+    RevokeApiToken {
+        user_id: i64,
+        api_token: String,
+    },
+    StoreNewApiToken {
+        user_id: i64,
+        api_token: String,
+    },
+    GetApiTokensForUser {
+        user_id: i64,
+        result_sender: oneshot::Sender<Result<Vec<String>>>,
+    },
 }

--- a/config.example.toml
+++ b/config.example.toml
@@ -26,3 +26,8 @@ hf_token = "<API_KEY>" # Hugging face api token, required if you want to access 
 
 [atoma_proxy_service]
 service_bind_address = "0.0.0.0:8081"
+
+[atoma_auth]
+secret_key = "secret_key" # Secret key for the tokens generation
+access_token_lifetime = 1 # In minutes
+refresh_token_lifetime = 1 # In days


### PR DESCRIPTION
Add atoma-auth module, this modules takes care of the jwt and api token validation.
The api token can be generated only when a valid jwt access token is provided.
Valid jwt access tokens holds the hash of the refresh token that was used to generate it. If the refresh token is not in the DB (was revoked) all the corresponding access tokens are revoked as well.