### PR TITLE
feat: add stats for the dashboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,6 +629,7 @@ name = "atoma-state"
 version = "0.1.0"
 dependencies = [
  "atoma-sui",
+ "chrono",
  "config",
  "flume",
  "serde",
@@ -6786,6 +6787,7 @@ dependencies = [
  "atoi",
  "byteorder",
  "bytes",
+ "chrono",
  "crc",
  "crossbeam-queue",
  "either",
@@ -6867,6 +6869,7 @@ dependencies = [
  "bitflags 2.6.0",
  "byteorder",
  "bytes",
+ "chrono",
  "crc",
  "digest 0.10.7",
  "dotenvy",
@@ -6908,6 +6911,7 @@ dependencies = [
  "base64 0.22.1",
  "bitflags 2.6.0",
  "byteorder",
+ "chrono",
  "crc",
  "dotenvy",
  "etcetera",
@@ -6943,6 +6947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5b2cf34a45953bfd3daaf3db0f7a7878ab9b7a6b91b422d24a7a9e4c857b680"
 dependencies = [
  "atoi",
+ "chrono",
  "flume",
  "futures-channel",
  "futures-core",

--- a/atoma-proxy-service/docs/openapi.yml
+++ b/atoma-proxy-service/docs/openapi.yml
@@ -30,6 +30,46 @@ paths:
           description: Unauthorized request
         '500':
           description: Failed to get all api tokens
+  /compute_units_processed:
+    get:
+      tags:
+      - Stats
+      summary: ' Get compute unit processed in the last `hours` hours per model.'
+      description: |2-
+         # Arguments
+
+         * `proxy_service_state` - The shared state containing the state manager
+         * `query` - The query containing the number of hours to look back
+
+         # Returns
+
+         * `Result<Json<Vec<ComputedUnitsProcessedResponse>>` - A JSON response containing a list of computed units processed
+           - `Ok(Json<Vec<ComputedUnitsProcessedResponse>>)` - Successfully retrieved computed units processed
+           - `Err(StatusCode::INTERNAL_SERVER_ERROR)` - Failed to retrieve computed units processed from state manager
+
+         # Example Response
+
+         Returns a JSON array of ComputedUnitsProcessedResponse objects for the specified hours
+         ```json
+         [
+            {
+                timestamp: "2024-03-21T12:00:00Z",
+                model_name: "example_model",
+                amount: 123,
+                requests: 2,
+                time: 45
+           }
+        ]
+        ```
+      operationId: get_compute_units_processed
+      responses:
+        '200':
+          description: Retrieves all computed units processed
+          content:
+            application/json:
+              schema: {}
+        '500':
+          description: Failed to get performance
   /generate_api_token:
     get:
       tags:
@@ -66,6 +106,45 @@ paths:
           description: Service is healthy
         '500':
           description: Service is unhealthy
+  /latency:
+    get:
+      tags:
+      - Stats
+      summary: Get latency performance in the last `hours` hours.
+      description: |-
+        # Arguments
+
+        * `proxy_service_state` - The shared state containing the state manager
+        * `query` - The query containing the number of hours to look back
+
+        # Returns
+
+        * `Result<Json<Vec<LatencyResponse>>` - A JSON response containing a list of latency performance
+          - `Ok(Json<Vec<LatencyResponse>>)` - Successfully retrieved latency performance
+          - `Err(StatusCode::INTERNAL_SERVER_ERROR)` - Failed to retrieve latency performance from state manager
+
+        # Example Response
+
+        Returns a JSON array of LatencyResponse objects for the specified hours
+        ```json
+        [
+          {
+             timestamp: "2024-03-21T12:00:00Z",
+             latency: 123,
+             requests: 2,
+             time: 45
+          }
+        ]
+        ```
+      operationId: get_latency
+      responses:
+        '200':
+          description: Retrieves all latency performance
+          content:
+            application/json:
+              schema: {}
+        '500':
+          description: Failed to get performance
   /login:
     post:
       tags:
@@ -268,5 +347,7 @@ tags:
   description: Stack operations
 - name: get_tasks
   description: Task management
+- name: get_stats
+  description: Stats and metrics
 - name: get_subscriptions
   description: Node subscription management

--- a/atoma-proxy-service/docs/openapi.yml
+++ b/atoma-proxy-service/docs/openapi.yml
@@ -331,23 +331,15 @@ components:
         api_token:
           type: string
 tags:
-- name: health
+- name: Health
   description: Health check endpoints
-- name: generate_api_token
+- name: Auth
   description: Authentication and API token management
-- name: revoke_api_token
-  description: Authentication and API token management
-- name: register
-  description: Authentication and API token management
-- name: login
-  description: Authentication and API token management
-- name: get_all_api_tokens
-  description: Authentication and API token management
-- name: get_stacks
-  description: Stack operations
-- name: get_tasks
-  description: Task management
-- name: get_stats
+- name: Tasks
+  description: Atoma's Tasks management
+- name: Subscriptions
+  description: Node task subscriptions management
+- name: Stacks
+  description: Stacks management
+- name: Stats
   description: Stats and metrics
-- name: get_subscriptions
-  description: Node subscription management

--- a/atoma-proxy-service/src/components/openapi.rs
+++ b/atoma-proxy-service/src/components/openapi.rs
@@ -10,6 +10,7 @@ use crate::{
             REGISTER_PATH, REVOKE_API_TOKEN_PATH,
         },
         stacks::{GetCurrentStacksOpenApi, GET_STACKS_PATH},
+        stats::{GetComputeUnitsProcessed, GetLatency, COMPUTE_UNITS_PROCESSED_PATH, LATENCY_PATH},
         subscriptions::{GetAllSubscriptionsOpenApi, SUBSCRIPTIONS_PATH},
         tasks::{GetAllTasksOpenApi, TASKS_PATH},
     },
@@ -28,6 +29,8 @@ pub fn openapi_router() -> Router {
             (path = GET_ALL_API_TOKENS_PATH, api = GetAllApiTokensOpenApi, tags = ["Auth"]),
             (path = GET_STACKS_PATH, api = GetCurrentStacksOpenApi, tags = ["Stacks"]),
             (path = TASKS_PATH, api = GetAllTasksOpenApi, tags = ["Tasks"]),
+            (path = COMPUTE_UNITS_PROCESSED_PATH, api = GetComputeUnitsProcessed, tags = ["Stats"]),
+            (path = LATENCY_PATH, api = GetLatency, tags = ["Stats"]),
             (path = SUBSCRIPTIONS_PATH, api = GetAllSubscriptionsOpenApi, tags = ["Subscriptions"]),
         ),
         tags(
@@ -36,6 +39,7 @@ pub fn openapi_router() -> Router {
             (name = "Tasks", description = "Atoma's Tasks management"),
             (name = "Subscriptions", description = "Node task subscriptions management"),
             (name = "Stacks", description = "Stacks management"),
+            (name = "Stats", description = "Stats and metrics"),
         ),
         servers(
             (url = "http://localhost:3005", description = "Local server"),

--- a/atoma-proxy-service/src/handlers/mod.rs
+++ b/atoma-proxy-service/src/handlers/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod auth;
 pub(crate) mod stacks;
+pub(crate) mod stats;
 pub(crate) mod subscriptions;
 pub(crate) mod tasks;

--- a/atoma-proxy-service/src/handlers/stats.rs
+++ b/atoma-proxy-service/src/handlers/stats.rs
@@ -1,0 +1,152 @@
+use atoma_state::types::{ComputedUnitsProcessedResponse, LatencyResponse};
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    routing::get,
+    Json, Router,
+};
+use tracing::{error, instrument};
+use utoipa::OpenApi;
+
+use crate::{ComputeUnitsProcessedQuery, LatencyQuery, ProxyServiceState};
+
+type Result<T> = std::result::Result<T, StatusCode>;
+
+/// The path for the compute_units_processed endpoint.
+pub(crate) const COMPUTE_UNITS_PROCESSED_PATH: &str = "/compute_units_processed";
+/// The path for the compute_units_processed endpoint.
+pub(crate) const LATENCY_PATH: &str = "/latency";
+
+/// Returns a router with the stats endpoint.
+///
+/// # Returns
+/// * `Router<ProxyServiceState>` - A router with the stacks endpoint
+pub(crate) fn stats_router() -> Router<ProxyServiceState> {
+    Router::new()
+        .route(
+            COMPUTE_UNITS_PROCESSED_PATH,
+            get(get_compute_units_processed),
+        )
+        .route(LATENCY_PATH, get(get_latency))
+}
+
+/// OpenAPI documentation for the get_compute_units_processed endpoint.
+///
+/// This struct is used to generate OpenAPI documentation for the get_compute_units_processed
+/// endpoint. It uses the `utoipa` crate's derive macro to automatically generate
+/// the OpenAPI specification from the code.
+#[derive(OpenApi)]
+#[openapi(paths(get_compute_units_processed))]
+pub(crate) struct GetComputeUnitsProcessed;
+
+/// Get compute unit processed in the last `hours` hours per model.
+///
+/// # Arguments
+///
+/// * `proxy_service_state` - The shared state containing the state manager
+/// * `query` - The query containing the number of hours to look back
+///
+/// # Returns
+///
+/// * `Result<Json<Vec<ComputedUnitsProcessedResponse>>` - A JSON response containing a list of computed units processed
+///   - `Ok(Json<Vec<ComputedUnitsProcessedResponse>>)` - Successfully retrieved computed units processed
+///   - `Err(StatusCode::INTERNAL_SERVER_ERROR)` - Failed to retrieve computed units processed from state manager
+///
+/// # Example Response
+///
+/// Returns a JSON array of ComputedUnitsProcessedResponse objects for the specified hours
+/// ```json
+/// [
+///    {
+///        timestamp: "2024-03-21T12:00:00Z",
+///        model_name: "example_model",
+///        amount: 123,
+///        requests: 2,
+///        time: 45
+///   }
+///]
+///```
+#[utoipa::path(
+  get,
+  path = "",
+  responses(
+      (status = OK, description = "Retrieves all computed units processed", body = Value),
+      (status = INTERNAL_SERVER_ERROR, description = "Failed to get performance")
+  )
+)]
+#[instrument(level = "trace", skip_all)]
+async fn get_compute_units_processed(
+    State(proxy_service_state): State<ProxyServiceState>,
+    Query(query): Query<ComputeUnitsProcessedQuery>,
+) -> Result<Json<Vec<ComputedUnitsProcessedResponse>>> {
+    Ok(Json(
+        proxy_service_state
+            .atoma_state
+            .get_compute_units_processed(query.hours)
+            .await
+            .map_err(|_| {
+                error!("Failed to get performance");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?,
+    ))
+}
+
+/// OpenAPI documentation for the get_latency endpoint.
+///
+/// This struct is used to generate OpenAPI documentation for the get_latency
+/// endpoint. It uses the `utoipa` crate's derive macro to automatically generate
+/// the OpenAPI specification from the code.
+#[derive(OpenApi)]
+#[openapi(paths(get_latency))]
+pub(crate) struct GetLatency;
+
+/// Get latency performance in the last `hours` hours.
+///
+/// # Arguments
+///
+/// * `proxy_service_state` - The shared state containing the state manager
+/// * `query` - The query containing the number of hours to look back
+///
+/// # Returns
+///
+/// * `Result<Json<Vec<LatencyResponse>>` - A JSON response containing a list of latency performance
+///   - `Ok(Json<Vec<LatencyResponse>>)` - Successfully retrieved latency performance
+///   - `Err(StatusCode::INTERNAL_SERVER_ERROR)` - Failed to retrieve latency performance from state manager
+///
+/// # Example Response
+///
+/// Returns a JSON array of LatencyResponse objects for the specified hours
+/// ```json
+/// [
+///   {
+///      timestamp: "2024-03-21T12:00:00Z",
+///      latency: 123,
+///      requests: 2,
+///      time: 45
+///   }
+/// ]
+/// ```
+#[utoipa::path(
+  get,
+  path = "",
+  responses(
+      (status = OK, description = "Retrieves all latency performance", body = Value),
+      (status = INTERNAL_SERVER_ERROR, description = "Failed to get performance")
+  )
+)]
+#[instrument(level = "trace", skip_all)]
+async fn get_latency(
+    State(proxy_service_state): State<ProxyServiceState>,
+    Query(query): Query<LatencyQuery>,
+) -> Result<Json<Vec<LatencyResponse>>> {
+    Ok(Json(
+        proxy_service_state
+            .atoma_state
+            .get_latency_performance(query.hours)
+            .await
+            .map_err(|_| {
+                error!("Failed to get performance");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?,
+    ))
+}

--- a/atoma-proxy-service/src/handlers/stats.rs
+++ b/atoma-proxy-service/src/handlers/stats.rs
@@ -100,7 +100,9 @@ async fn get_compute_units_processed(
 #[openapi(paths(get_latency))]
 pub(crate) struct GetLatency;
 
-/// Get latency performance in the last `hours` hours.
+/// Get latency performance of the network for last 'query.hours' hours. E.g. get latency performance for last 2 hours.
+/// The response is vector of LatencyResponse objects.
+/// For each hour the response contains sum of the latencies (in seconds) and number of requests made in that hour.
 ///
 /// # Arguments
 ///

--- a/atoma-proxy-service/src/lib.rs
+++ b/atoma-proxy-service/src/lib.rs
@@ -2,6 +2,8 @@ mod components;
 mod config;
 mod handlers;
 mod proxy_service;
+mod query;
 
 pub use config::AtomaProxyServiceConfig;
 pub use proxy_service::*;
+pub use query::*;

--- a/atoma-proxy-service/src/proxy_service.rs
+++ b/atoma-proxy-service/src/proxy_service.rs
@@ -14,8 +14,8 @@ use utoipa::OpenApi;
 use crate::{
     components::openapi::openapi_router,
     handlers::{
-        auth::auth_router, stacks::stacks_router, subscriptions::subscriptions_router,
-        tasks::tasks_router,
+        auth::auth_router, stacks::stacks_router, stats::stats_router,
+        subscriptions::subscriptions_router, tasks::tasks_router,
     },
 };
 
@@ -140,6 +140,7 @@ pub fn create_proxy_service_router(proxy_service_state: ProxyServiceState) -> Ro
         .merge(stacks_router())
         .merge(subscriptions_router())
         .merge(tasks_router())
+        .merge(stats_router())
         .layer(cors)
         .with_state(proxy_service_state)
         .route(HEALTH_PATH, get(health))

--- a/atoma-proxy-service/src/query.rs
+++ b/atoma-proxy-service/src/query.rs
@@ -1,12 +1,12 @@
 use serde::Deserialize;
 
-/// A latency query that can be deserialized from a request.
+/// A query params for latency requests. Since the latencies are on hourly basis. It will return last `LatencyQuery::hours` hours of latencies.
 #[derive(Deserialize)]
 pub struct LatencyQuery {
     pub hours: usize,
 }
 
-/// A compute units processed query that can be deserialized from a request.
+/// A query params for compute units processed requests. Since the compute units are on hourly basis. It will return last `ComputeUnitsProcessedQuery::hours` hours of compute units processed.
 #[derive(Deserialize)]
 pub struct ComputeUnitsProcessedQuery {
     pub hours: usize,

--- a/atoma-proxy-service/src/query.rs
+++ b/atoma-proxy-service/src/query.rs
@@ -1,0 +1,13 @@
+use serde::Deserialize;
+
+/// A latency query that can be deserialized from a request.
+#[derive(Deserialize)]
+pub struct LatencyQuery {
+    pub hours: usize,
+}
+
+/// A compute units processed query that can be deserialized from a request.
+#[derive(Deserialize)]
+pub struct ComputeUnitsProcessedQuery {
+    pub hours: usize,
+}

--- a/atoma-proxy/docs/openapi.yml
+++ b/atoma-proxy/docs/openapi.yml
@@ -10,7 +10,8 @@ servers:
 paths:
   /health:
     get:
-      tags: []
+      tags:
+      - Health
       summary: Handles the health check request.
       description: |-
         This endpoint is used to check the health of the atoma proxy service.
@@ -29,7 +30,8 @@ paths:
           description: Service is unhealthy
   /node/registration:
     post:
-      tags: []
+      tags:
+      - Node Public Address Registration
       summary: Handles the registration of a node's public address.
       description: |-
         This endpoint allows nodes to register or update their public address in the system.
@@ -71,7 +73,8 @@ paths:
           description: Failed to register node public address
   /v1/chat/completions:
     post:
-      tags: []
+      tags:
+      - Chat Completions
       summary: Handles the chat completions request.
       description: |-
         This function processes chat completion requests by determining whether to use streaming
@@ -117,7 +120,8 @@ paths:
           description: Internal server error
   /v1/embeddings:
     post:
-      tags: []
+      tags:
+      - Embeddings
       summary: Handles incoming embeddings requests by forwarding them to the appropriate AI node.
       description: |-
         This endpoint follows the OpenAI API format for generating vector embeddings from input text.
@@ -159,7 +163,8 @@ paths:
           description: Internal server error
   /v1/images/generations:
     post:
-      tags: []
+      tags:
+      - Image Generations
       summary: Handles incoming requests for AI image generation.
       description: |-
         This endpoint processes requests to generate images using AI models by forwarding them
@@ -207,7 +212,8 @@ paths:
           description: Internal server error
   /v1/models:
     get:
-      tags: []
+      tags:
+      - Models
       summary: Handles requests to list available AI models.
       description: |-
         This endpoint mimics the OpenAI models endpoint format, returning a list of
@@ -278,17 +284,15 @@ paths:
           description: Failed to retrieve list of available models
 components: {}
 tags:
-- name: health
+- name: Health
   description: Health check
-- name: chat
+- name: Chat Completions
   description: Chat completions
-- name: models
+- name: Models
   description: Models
-- name: node-public-address-registration
+- name: Node Public Address Registration
   description: Node public address registration
-- name: chat-completions
-  description: OpenAI's API chat completions v1 endpoint
-- name: embeddings
+- name: Embeddings
   description: OpenAI's API embeddings v1 endpoint
-- name: image-generations
+- name: Image Generations
   description: OpenAI's API image generations v1 endpoint

--- a/atoma-proxy/src/server/middleware.rs
+++ b/atoma-proxy/src/server/middleware.rs
@@ -258,17 +258,17 @@ pub async fn authenticate_middleware(
         })?;
         headers.insert(constants::TX_DIGEST, tx_digest_header);
     }
-    let request_model = RequestModelChatCompletions::new(&body_json).map_err(|_| {
-        error!("Failed to parse body as chat completions request model");
-        StatusCode::BAD_REQUEST
-    })?;
+    let request_model = body_json
+        .get("model")
+        .and_then(|m| m.as_str())
+        .ok_or(StatusCode::BAD_REQUEST)?;
     req_parts.extensions.insert(RequestMetadataExtension {
         node_address,
         node_id,
         num_compute_units,
         selected_stack_small_id: stack_small_id,
         endpoint: endpoint.clone(),
-        model_name: request_model.get_model()?,
+        model_name: request_model.to_string(),
         ..Default::default()
     });
     utils::handle_confidential_compute_content(state, &mut headers, &endpoint, node_id).await?;

--- a/atoma-proxy/src/server/middleware.rs
+++ b/atoma-proxy/src/server/middleware.rs
@@ -89,6 +89,9 @@ pub struct RequestMetadataExtension {
 
     /// Optional node x25519 public key used for encrypting this this request.
     pub node_x25519_public_key: Option<PublicKey>,
+
+    /// Model name
+    pub model_name: String,
 }
 
 impl RequestMetadataExtension {
@@ -255,12 +258,17 @@ pub async fn authenticate_middleware(
         })?;
         headers.insert(constants::TX_DIGEST, tx_digest_header);
     }
+    let request_model = RequestModelChatCompletions::new(&body_json).map_err(|_| {
+        error!("Failed to parse body as chat completions request model");
+        StatusCode::BAD_REQUEST
+    })?;
     req_parts.extensions.insert(RequestMetadataExtension {
         node_address,
         node_id,
         num_compute_units,
         selected_stack_small_id: stack_small_id,
         endpoint: endpoint.clone(),
+        model_name: request_model.get_model()?,
         ..Default::default()
     });
     utils::handle_confidential_compute_content(state, &mut headers, &endpoint, node_id).await?;

--- a/atoma-state/Cargo.toml
+++ b/atoma-state/Cargo.toml
@@ -6,11 +6,12 @@ license.workspace = true
 
 [dependencies]
 atoma-sui = { workspace = true }
+chrono.workspace = true
 config = { workspace = true }
 flume = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-sqlx = { workspace = true, features = ["runtime-tokio-native-tls", "sqlite"] }
+sqlx = { workspace = true, features = ["chrono", "runtime-tokio-native-tls", "sqlite"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }

--- a/atoma-state/src/handlers.rs
+++ b/atoma-state/src/handlers.rs
@@ -846,6 +846,8 @@ pub(crate) async fn handle_state_manager_event(
             handle_stack_created_event(state_manager, event, already_computed_units).await?;
         }
         AtomaAtomaStateManagerEvent::UpdateNodeThroughputPerformance {
+            timestamp,
+            model_name,
             node_small_id,
             input_tokens,
             output_tokens,
@@ -857,6 +859,15 @@ pub(crate) async fn handle_state_manager_event(
                     node_small_id,
                     input_tokens,
                     output_tokens,
+                    time,
+                )
+                .await?;
+            state_manager
+                .state
+                .add_compute_units_processed(
+                    timestamp,
+                    model_name,
+                    input_tokens + output_tokens,
                     time,
                 )
                 .await?;
@@ -882,6 +893,7 @@ pub(crate) async fn handle_state_manager_event(
                 .await?;
         }
         AtomaAtomaStateManagerEvent::UpdateNodeLatencyPerformance {
+            timestamp,
             node_small_id,
             latency,
         } => {
@@ -889,6 +901,7 @@ pub(crate) async fn handle_state_manager_event(
                 .state
                 .update_node_latency_performance(node_small_id, latency)
                 .await?;
+            state_manager.state.add_latency(timestamp, latency).await?;
         }
         AtomaAtomaStateManagerEvent::GetSelectedNodeX25519PublicKey {
             selected_node_id,

--- a/atoma-state/src/types.rs
+++ b/atoma-state/src/types.rs
@@ -26,19 +26,43 @@ pub struct AuthResponse {
     pub refresh_token: String,
 }
 
+/// Represents a computed units processed response
+/// This struct is used to represent the response for the get_compute_units_processed endpoint.
+/// The timestamp of the computed units processed measurement. We measure the computed units processed on hourly basis. We do these measurements for each model.
+/// So the timestamp is the hour for which it is measured.
+/// The amount is the sum of all computed units processed in that hour. The requests is the total number of requests in that hour.
+/// And the time is the time taken to process all computed units in that hour.
+///
+/// E.g. you have two requests in the hour, one with 10 computed units and the other with 20 computed units.
+/// The amount will be 30, the requests will be 2 and the time will be the sum of the time taken to process the 10 and 20 computed units.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, FromRow)]
 pub struct ComputedUnitsProcessedResponse {
+    /// Timestamp of the computed units processed measurement
     pub timestamp: DateTime<Utc>,
+    /// Name of the model
     pub model_name: String,
+    /// Amount of all computed units processed
     pub amount: i64,
+    /// Number of requests
     pub requests: i64,
+    /// Time (in seconds) taken to process all computed units
     pub time: f64,
 }
 
+/// Represents a latency response
+/// This struct is used to represent the response for the get_latency endpoint.
+/// The timestamp of the latency measurement. We measure the latency on hourly basis. So the timestamp is the hour for which it is measured.
+/// The latency is the sum of all latencies in that hour. And the number of requests is the total number of requests in that hour.
+///
+/// E.g. you have two requests in the hour, one with 1 second latency and the other with 2 seconds latency.
+/// The latency will be 3 seconds and the requests will be 2.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, FromRow)]
 pub struct LatencyResponse {
+    /// Timestamp of the latency measurement
     pub timestamp: DateTime<Utc>,
+    /// Sum of all latencies (in seconds) in that hour
     pub latency: f64,
+    /// Total number of requests in that hour
     pub requests: i64,
 }
 /// Represents a task in the system

--- a/atoma-state/src/types.rs
+++ b/atoma-state/src/types.rs
@@ -1,6 +1,7 @@
 use atoma_sui::events::{
     StackAttestationDisputeEvent, StackCreatedEvent, StackTrySettleEvent, TaskRegisteredEvent,
 };
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use tokio::sync::oneshot;
@@ -23,6 +24,22 @@ pub struct AuthRequest {
 pub struct AuthResponse {
     pub access_token: String,
     pub refresh_token: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, FromRow)]
+pub struct ComputedUnitsProcessedResponse {
+    pub timestamp: DateTime<Utc>,
+    pub model_name: String,
+    pub amount: i64,
+    pub requests: i64,
+    pub time: f64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, FromRow)]
+pub struct LatencyResponse {
+    pub timestamp: DateTime<Utc>,
+    pub latency: f64,
+    pub requests: i64,
 }
 /// Represents a task in the system
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, FromRow)]
@@ -281,6 +298,8 @@ pub enum AtomaAtomaStateManagerEvent {
         already_computed_units: i64,
     },
     UpdateNodeThroughputPerformance {
+        timestamp: DateTime<Utc>,
+        model_name: String,
         node_small_id: i64,
         input_tokens: i64,
         output_tokens: i64,
@@ -297,6 +316,7 @@ pub enum AtomaAtomaStateManagerEvent {
         time: f64,
     },
     UpdateNodeLatencyPerformance {
+        timestamp: DateTime<Utc>,
         node_small_id: i64,
         latency: f64,
     },


### PR DESCRIPTION
Add stats for the dashboard,
- hourly based latency
- hourly based compute units processed
Add daemons endpoints and tables for both of them. They are updated whenever we update the nodes performances tables.