### PR TITLE
feat: validate api token on inference request

### DIFF
--- a/atoma-state/src/handlers.rs
+++ b/atoma-state/src/handlers.rs
@@ -970,14 +970,10 @@ pub(crate) async fn handle_state_manager_event(
                 .await?;
         }
         AtomaAtomaStateManagerEvent::IsApiTokenValid {
-            user_id,
             api_token,
             result_sender,
         } => {
-            let is_valid = state_manager
-                .state
-                .is_api_token_valid(user_id, &api_token)
-                .await;
+            let is_valid = state_manager.state.is_api_token_valid(&api_token).await;
             result_sender
                 .send(is_valid)
                 .map_err(|_| AtomaStateManagerError::ChannelSendError)?;

--- a/atoma-state/src/state_manager.rs
+++ b/atoma-state/src/state_manager.rs
@@ -2910,14 +2910,11 @@ impl AtomaState {
     /// }
     /// ```
     #[instrument(level = "trace", skip(self))]
-    pub async fn is_api_token_valid(&self, user_id: i64, api_token: &str) -> Result<bool> {
-        let is_valid = sqlx::query(
-            "SELECT EXISTS(SELECT 1 FROM api_tokens WHERE user_id = $1 AND token = $2)",
-        )
-        .bind(user_id)
-        .bind(api_token)
-        .fetch_one(&self.db)
-        .await?;
+    pub async fn is_api_token_valid(&self, api_token: &str) -> Result<bool> {
+        let is_valid = sqlx::query("SELECT EXISTS(SELECT 1 FROM api_tokens WHERE token = $1)")
+            .bind(api_token)
+            .fetch_one(&self.db)
+            .await?;
 
         Ok(is_valid.get::<bool, _>(0))
     }

--- a/atoma-state/src/types.rs
+++ b/atoma-state/src/types.rs
@@ -372,7 +372,6 @@ pub enum AtomaAtomaStateManagerEvent {
         refresh_token_hash: String,
     },
     IsApiTokenValid {
-        user_id: i64,
         api_token: String,
         result_sender: oneshot::Sender<Result<bool>>,
     },


### PR DESCRIPTION
Validate the api token on inference request (check if it's in the DB, all revoked tokens are deleted).