### PR TITLE
chore: cleanup the leftovers after static password removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ database_url = "postgresql://POSTGRES_USER:POSTGRES_PASSWORD@db:5432/POSTGRES_DB
 
 [atoma_service]
 service_bind_address = "0.0.0.0:8080" # Address to bind the service to
-password = "password" # Password for the service
 models = [
   "meta-llama/Llama-3.2-3B-Instruct",
   "meta-llama/Llama-3.2-1B-Instruct",

--- a/atoma-proxy/src/server/middleware.rs
+++ b/atoma-proxy/src/server/middleware.rs
@@ -459,7 +459,7 @@ pub(crate) mod auth {
     ///
     /// # Arguments
     ///
-    /// * `state` - The proxy state containing password, models, and other shared state
+    /// * `state` - The proxy state containing models, and other shared state
     /// * `headers` - Request headers containing authorization
     /// * `payload` - Request payload containing model and token information
     ///
@@ -566,11 +566,11 @@ pub(crate) mod auth {
     /// Checks the authentication of the request.
     ///
     /// This function checks the authentication of the request by comparing the
-    /// provided password with the `Authorization` header in the request.
+    /// provided Bearer token from the `Authorization` header against the stored tokens.
     ///
     /// # Arguments
     ///
-    /// * `password`: The password to check against.
+    /// * `state_manager_sender`: The sender for the state manager channel.
     /// * `headers`: The headers of the request.
     ///
     /// # Returns

--- a/atoma-proxy/src/server/middleware.rs
+++ b/atoma-proxy/src/server/middleware.rs
@@ -621,7 +621,7 @@ pub(crate) mod auth {
                 }
             }
         }
-        error!("Invalid or missing password for request");
+        error!("Invalid or missing api token for request");
         Err(StatusCode::UNAUTHORIZED)
     }
 


### PR DESCRIPTION
Just remove the missed static proxy password references.