### PR TITLE
feat: add confidential chat completion request and response schemas

### DIFF
--- a/atoma-proxy/docs/openapi.yml
+++ b/atoma-proxy/docs/openapi.yml
@@ -299,7 +299,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ConfidentialChatCompletionResponse'
+                $ref: '#/components/schemas/ConfidentialComputeRequest'
         '400':
           description: Bad request
         '401':
@@ -386,7 +386,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateEmbeddingRequest'
+              $ref: '#/components/schemas/ConfidentialComputeRequest'
         required: true
       responses:
         '200':
@@ -394,7 +394,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreateEmbeddingResponse'
+                $ref: '#/components/schemas/ConfidentialComputeRequest'
         '400':
           description: Bad request
         '401':
@@ -460,34 +460,12 @@ paths:
     post:
       tags:
       - Confidential Images
-      summary: Create confidential image generations
-      description: |-
-        This endpoint follows the OpenAI API format for generating images,
-        but with confidential processing (through AEAD encryption and TEE hardware).
-        The handler receives pre-processed metadata from middleware and forwards the request to
-        the selected node.
-
-        Note: Authentication, node selection, initial request validation and encryption
-        are handled by middleware before this handler is called.
-
-        # Arguments
-        * `metadata` - Pre-processed request metadata containing node information and compute units
-        * `state` - The shared proxy state containing configuration and runtime information
-        * `headers` - HTTP headers from the incoming request
-        * `payload` - The JSON request body containing the model and input text
-
-        # Returns
-        * `Ok(Response)` - The image generations response from the processing node
-        * `Err(AtomaProxyError)` - An error status code if any step fails
-
-        # Errors
-        * `INTERNAL_SERVER_ERROR` - Processing or node communication failures
       operationId: confidential_image_generations_create
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateImageRequest'
+              $ref: '#/components/schemas/ConfidentialComputeRequest'
         required: true
       responses:
         '200':
@@ -495,7 +473,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreateImageResponse'
+                $ref: '#/components/schemas/ConfidentialComputeRequest'
         '400':
           description: Bad request
         '401':
@@ -867,31 +845,55 @@ components:
           - boolean
           - 'null'
           description: Whether to stream back partial progress
-    ConfidentialChatCompletionResponse:
+    ConfidentialComputeRequest:
       type: object
-      description: Response format for confidential chat completions
+      description: A request for confidential computation that includes encrypted data and associated cryptographic parameters
       required:
       - ciphertext
-      - node_dh_public_key
+      - stack_small_id
       - nonce
-      - plaintext_body_hash
       - salt
+      - client_dh_public_key
+      - plaintext_body_hash
+      - model_name
       properties:
         ciphertext:
           type: string
-          description: The encrypted ChatCompletionResponse
-        node_dh_public_key:
+          description: The encrypted payload that needs to be processed (base64 encoded)
+        client_dh_public_key:
           type: string
-          description: Node's DH public key for key exchange
+          description: Client's public key for Diffie-Hellman key exchange (base64 encoded)
+        max_tokens:
+          type:
+          - integer
+          - 'null'
+          format: int64
+          description: |-
+            Number of compute units to be used for the request, for image generations,
+            as this value is known in advance (the number of pixels to generate)
+          minimum: 0
+        model_name:
+          type: string
+          description: Model name
         nonce:
           type: string
-          description: Nonce used for encryption
+          description: Cryptographic nonce used for encryption (base64 encoded)
         plaintext_body_hash:
           type: string
-          description: Hash of the plaintext body for verification
+          description: Hash of the original plaintext body for integrity verification (base64 encoded)
         salt:
           type: string
-          description: Salt used for encryption
+          description: Salt value used in key derivation (base64 encoded)
+        stack_small_id:
+          type: integer
+          format: int64
+          description: Unique identifier for the small stack being used
+          minimum: 0
+        stream:
+          type:
+          - boolean
+          - 'null'
+          description: Indicates whether this is a streaming request
     CreateChatCompletionRequest:
       allOf:
       - $ref: '#/components/schemas/ChatCompletionRequest'

--- a/atoma-proxy/docs/openapi.yml
+++ b/atoma-proxy/docs/openapi.yml
@@ -207,8 +207,6 @@ paths:
           description: Chat completions
           content:
             text/event-stream:
-              # DO NOT DELETE:This is a custom extension required by Speakeasy to handle SSE
-              x-speakeasy-sse-sentinel: '[DONE]'
               schema:
                 $ref: '#/components/schemas/ChatCompletionStreamResponse'
         '400':
@@ -284,7 +282,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateChatCompletionRequest'
+              $ref: '#/components/schemas/ConfidentialChatCompletionRequest'
         required: true
       responses:
         '200':
@@ -292,7 +290,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ChatCompletionResponse'
+                $ref: '#/components/schemas/ConfidentialChatCompletionResponse'
         '400':
           description: Bad request
         '401':
@@ -819,6 +817,72 @@ components:
           type: integer
           format: int32
           description: Total number of tokens used (prompt + completion).
+    ConfidentialChatCompletionRequest:
+      type: object
+      description: Request format for confidential chat completions
+      required:
+      - ciphertext
+      - client_dh_public_key
+      - nonce
+      - plaintext_body_hash
+      - salt
+      - stack_small_id
+      properties:
+        ciphertext:
+          type: string
+          description: The encrypted CreateChatCompletionRequest
+        client_dh_public_key:
+          type: string
+          description: Client's DH public key for key exchange
+        max_tokens:
+          type:
+          - integer
+          - 'null'
+          format: int32
+          description: The maximum number of tokens to generate
+        nonce:
+          type: string
+          description: Nonce used for encryption
+        plaintext_body_hash:
+          type: string
+          description: Hash of the plaintext body for verification
+        salt:
+          type: string
+          description: Salt used for encryption
+        stack_small_id:
+          type: integer
+          format: int64
+          description: The small ID of the stack
+        stream:
+          type:
+          - boolean
+          - 'null'
+          description: Whether to stream back partial progress
+    ConfidentialChatCompletionResponse:
+      type: object
+      description: Response format for confidential chat completions
+      required:
+      - ciphertext
+      - node_dh_public_key
+      - nonce
+      - plaintext_body_hash
+      - salt
+      properties:
+        ciphertext:
+          type: string
+          description: The encrypted ChatCompletionResponse
+        node_dh_public_key:
+          type: string
+          description: Node's DH public key for key exchange
+        nonce:
+          type: string
+          description: Nonce used for encryption
+        plaintext_body_hash:
+          type: string
+          description: Hash of the plaintext body for verification
+        salt:
+          type: string
+          description: Salt used for encryption
     CreateChatCompletionRequest:
       allOf:
       - $ref: '#/components/schemas/ChatCompletionRequest'

--- a/atoma-proxy/src/server/handlers/chat_completions.rs
+++ b/atoma-proxy/src/server/handlers/chat_completions.rs
@@ -291,8 +291,9 @@ pub(crate) struct ConfidentialChatCompletionsOpenApi;
     security(
         ("bearerAuth" = [])
     ),
+    request_body = ConfidentialChatCompletionRequest,
     responses(
-        (status = OK, description = "Confidential chat completions", body = ChatCompletionResponse),
+        (status = OK, description = "Confidential chat completions", body = ConfidentialChatCompletionResponse),
         (status = BAD_REQUEST, description = "Bad request"),
         (status = UNAUTHORIZED, description = "Unauthorized"),
         (status = INTERNAL_SERVER_ERROR, description = "Internal server error")
@@ -979,4 +980,40 @@ pub struct ChatCompletionChunkDelta {
     /// The tool calls information, if present in this chunk.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<Vec<Value>>,
+}
+
+/// Request format for confidential chat completions
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct ConfidentialChatCompletionRequest {
+    /// The encrypted CreateChatCompletionRequest
+    pub ciphertext: String,
+    /// Client's DH public key for key exchange
+    pub client_dh_public_key: String,
+    /// Nonce used for encryption
+    pub nonce: String,
+    /// Hash of the plaintext body for verification
+    pub plaintext_body_hash: String,
+    /// Salt used for encryption
+    pub salt: String,
+    /// The small ID of the stack
+    pub stack_small_id: i64,
+    /// Whether to stream back partial progress
+    pub stream: Option<bool>,
+    /// The maximum number of tokens to generate
+    pub max_tokens: Option<i32>,
+}
+
+/// Response format for confidential chat completions
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct ConfidentialChatCompletionResponse {
+    /// The encrypted ChatCompletionResponse
+    pub ciphertext: String,
+    /// Node's DH public key for key exchange
+    pub node_dh_public_key: String,
+    /// Nonce used for encryption
+    pub nonce: String,
+    /// Hash of the plaintext body for verification
+    pub plaintext_body_hash: String,
+    /// Salt used for encryption
+    pub salt: String,
 }


### PR DESCRIPTION
- Introduced new schemas for ConfidentialChatCompletionRequest and ConfidentialChatCompletionResponse in the OpenAPI documentation.
- Updated the chat completions handler to utilize the new confidential request and response formats.
- Removed obsolete comments and references in the OpenAPI file.