### PR TITLE
feat: return stack timestamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,6 +635,7 @@ dependencies = [
  "atoma-state",
  "atoma-sui",
  "axum",
+ "chrono",
  "config",
  "serde",
  "serde_yaml 0.9.34+deprecated",

--- a/atoma-proxy-service/Cargo.toml
+++ b/atoma-proxy-service/Cargo.toml
@@ -10,6 +10,7 @@ atoma-auth.workspace = true
 atoma-state.workspace = true
 atoma-sui.workspace = true
 axum.workspace = true
+chrono.workspace = true
 config.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_yaml = { workspace = true }

--- a/atoma-proxy-service/src/handlers/stacks.rs
+++ b/atoma-proxy-service/src/handlers/stacks.rs
@@ -5,6 +5,7 @@ use axum::{
     routing::get,
     Json, Router,
 };
+use chrono::{DateTime, Utc};
 use tracing::{error, instrument};
 use utoipa::OpenApi;
 
@@ -151,7 +152,7 @@ pub(crate) struct GetStacksByUserId;
 pub(crate) async fn get_all_stacks_for_user(
     State(proxy_service_state): State<ProxyServiceState>,
     headers: HeaderMap,
-) -> Result<Json<Vec<Stack>>> {
+) -> Result<Json<Vec<(Stack, DateTime<Utc>)>>> {
     let auth_header = headers
         .get("Authorization")
         .ok_or(StatusCode::UNAUTHORIZED)?

--- a/atoma-proxy-service/src/handlers/stacks.rs
+++ b/atoma-proxy-service/src/handlers/stacks.rs
@@ -12,6 +12,7 @@ use utoipa::OpenApi;
 use crate::ProxyServiceState;
 
 type Result<T> = std::result::Result<T, StatusCode>;
+type StackWithTimeStamp = (Stack, DateTime<Utc>);
 
 /// The path for the get_current_stacks endpoint.
 pub(crate) const GET_CURRENT_STACKS_PATH: &str = "/current_stacks";
@@ -152,7 +153,7 @@ pub(crate) struct GetStacksByUserId;
 pub(crate) async fn get_all_stacks_for_user(
     State(proxy_service_state): State<ProxyServiceState>,
     headers: HeaderMap,
-) -> Result<Json<Vec<(Stack, DateTime<Utc>)>>> {
+) -> Result<Json<Vec<StackWithTimeStamp>>> {
     let auth_header = headers
         .get("Authorization")
         .ok_or(StatusCode::UNAUTHORIZED)?

--- a/atoma-proxy/docs/openapi.yml
+++ b/atoma-proxy/docs/openapi.yml
@@ -815,6 +815,7 @@ components:
       - nonce
       - salt
       - client_dh_public_key
+      - node_dh_public_key
       - plaintext_body_hash
       - model_name
       properties:
@@ -824,7 +825,16 @@ components:
         client_dh_public_key:
           type: string
           description: Client's public key for Diffie-Hellman key exchange (base64 encoded)
-        max_tokens:
+        model_name:
+          type: string
+          description: Model name
+        node_dh_public_key:
+          type: string
+          description: Node's public key for Diffie-Hellman key exchange (base64 encoded)
+        nonce:
+          type: string
+          description: Cryptographic nonce used for encryption (base64 encoded)
+        num_compute_units:
           type:
           - integer
           - 'null'
@@ -833,12 +843,6 @@ components:
             Number of compute units to be used for the request, for image generations,
             as this value is known in advance (the number of pixels to generate)
           minimum: 0
-        model_name:
-          type: string
-          description: Model name
-        nonce:
-          type: string
-          description: Cryptographic nonce used for encryption (base64 encoded)
         plaintext_body_hash:
           type: string
           description: Hash of the original plaintext body for integrity verification (base64 encoded)

--- a/atoma-proxy/src/server/handlers/embeddings.rs
+++ b/atoma-proxy/src/server/handlers/embeddings.rs
@@ -282,7 +282,7 @@ pub async fn confidential_embeddings_create(
                 &state.state_manager_sender,
                 metadata.selected_stack_small_id,
                 num_input_compute_units as i64,
-                total_tokens as i64,
+                total_tokens,
                 &metadata.endpoint,
             )?;
             Ok(Json(response).into_response())


### PR DESCRIPTION
Return stack timestamp alongside with the stack itself.
I don't want to add the timestamp to stack struct, because it would not reflect the event that's emitted.