### PR TITLE
feat: hardcode model capabilities into proxy

### DIFF
--- a/atoma-proxy-service/src/handlers/tasks.rs
+++ b/atoma-proxy-service/src/handlers/tasks.rs
@@ -8,7 +8,7 @@ use axum::{
 use tracing::{error, instrument};
 use utoipa::OpenApi;
 
-use crate::ProxyServiceState;
+use crate::{ModelCapabilities, ProxyServiceState};
 
 type Result<T> = std::result::Result<T, StatusCode>;
 
@@ -108,7 +108,7 @@ pub(crate) struct GetAllTasksOpenApi;
 #[instrument(level = "trace", skip_all)]
 pub(crate) async fn get_all_tasks(
     State(proxy_service_state): State<ProxyServiceState>,
-) -> Result<Json<Vec<Task>>> {
+) -> Result<Json<Vec<(Task, Vec<ModelCapabilities>)>>> {
     let all_tasks = proxy_service_state
         .atoma_state
         .get_all_tasks()
@@ -117,5 +117,17 @@ pub(crate) async fn get_all_tasks(
             error!("Failed to get all tasks");
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
-    Ok(Json(all_tasks))
+    Ok(Json(
+        all_tasks
+            .into_iter()
+            .map(|task| {
+                (
+                    task.clone(),
+                    task.model_name
+                        .map(|model| proxy_service_state.get_capabilities_for_model(&model))
+                        .unwrap_or_default(),
+                )
+            })
+            .collect(),
+    ))
 }

--- a/atoma-proxy-service/src/lib.rs
+++ b/atoma-proxy-service/src/lib.rs
@@ -9,9 +9,9 @@ pub use proxy_service::*;
 pub use query::*;
 use serde::{Deserialize, Serialize};
 
-/// Model Capabilities.
+/// Model modality
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum ModelCapabilities {
+pub enum ModelModality {
     #[serde(rename = "Chat Completions")]
     ChatCompletions,
     #[serde(rename = "Images Generations")]

--- a/atoma-proxy-service/src/lib.rs
+++ b/atoma-proxy-service/src/lib.rs
@@ -7,3 +7,14 @@ mod query;
 pub use config::AtomaProxyServiceConfig;
 pub use proxy_service::*;
 pub use query::*;
+use serde::{Deserialize, Serialize};
+
+/// Model Capabilities.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum ModelCapabilities {
+    #[serde(rename = "Chat Completions")]
+    ChatCompletions,
+    #[serde(rename = "Images Generations")]
+    ImagesGenerations,
+    Embeddings,
+}

--- a/atoma-proxy-service/src/proxy_service.rs
+++ b/atoma-proxy-service/src/proxy_service.rs
@@ -17,6 +17,7 @@ use crate::{
         auth::auth_router, stacks::stacks_router, stats::stats_router,
         subscriptions::subscriptions_router, tasks::tasks_router,
     },
+    ModelCapabilities,
 };
 
 /// The path for the health check endpoint.
@@ -57,6 +58,25 @@ pub struct ProxyServiceState {
 
     /// The authentication manager for the proxy service.
     pub auth: Auth,
+
+    /// List of models and their capabilities.
+    pub models_with_capabilities: Vec<(String, Vec<ModelCapabilities>)>,
+}
+
+impl ProxyServiceState {
+    /// Find the capabilities for a given model. If the model is not found, return an empty list.
+    pub fn get_capabilities_for_model(&self, model: &str) -> Vec<ModelCapabilities> {
+        self.models_with_capabilities
+            .iter()
+            .find_map(|(m, capabilities)| {
+                if m == model {
+                    Some(capabilities.clone())
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_default()
+    }
 }
 
 /// Starts and runs the Atoma proxy service service, handling HTTP requests and graceful shutdown.

--- a/atoma-proxy-service/src/proxy_service.rs
+++ b/atoma-proxy-service/src/proxy_service.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use atoma_auth::Auth;
 use atoma_state::AtomaState;
 use axum::{
@@ -17,7 +19,7 @@ use crate::{
         auth::auth_router, stacks::stacks_router, stats::stats_router,
         subscriptions::subscriptions_router, tasks::tasks_router,
     },
-    ModelCapabilities,
+    ModelModality,
 };
 
 /// The path for the health check endpoint.
@@ -59,24 +61,8 @@ pub struct ProxyServiceState {
     /// The authentication manager for the proxy service.
     pub auth: Auth,
 
-    /// List of models and their capabilities.
-    pub models_with_capabilities: Vec<(String, Vec<ModelCapabilities>)>,
-}
-
-impl ProxyServiceState {
-    /// Find the capabilities for a given model. If the model is not found, return an empty list.
-    pub fn get_capabilities_for_model(&self, model: &str) -> Vec<ModelCapabilities> {
-        self.models_with_capabilities
-            .iter()
-            .find_map(|(m, capabilities)| {
-                if m == model {
-                    Some(capabilities.clone())
-                } else {
-                    None
-                }
-            })
-            .unwrap_or_default()
-    }
+    /// List of models and their modalities.
+    pub models_with_modalities: HashMap<String, Vec<ModelModality>>,
 }
 
 /// Starts and runs the Atoma proxy service service, handling HTTP requests and graceful shutdown.

--- a/atoma-proxy/src/main.rs
+++ b/atoma-proxy/src/main.rs
@@ -181,6 +181,18 @@ async fn main() -> Result<()> {
         &config.service.hf_token,
     )
     .await?;
+
+    let models_with_capabilities = config
+        .service
+        .models
+        .iter()
+        .zip(config.service.capabilities.iter())
+        .map(|(model, capabilities)| {
+            let capabilities = capabilities.clone();
+            (model.clone(), capabilities)
+        })
+        .collect();
+
     let server_handle = spawn_with_shutdown(
         start_server(
             config.service,
@@ -199,6 +211,7 @@ async fn main() -> Result<()> {
     let proxy_service_state = ProxyServiceState {
         atoma_state: AtomaState::new_from_url(&config.state.database_url).await?,
         auth,
+        models_with_capabilities,
     };
 
     let proxy_service_handle = spawn_with_shutdown(

--- a/atoma-proxy/src/main.rs
+++ b/atoma-proxy/src/main.rs
@@ -182,14 +182,14 @@ async fn main() -> Result<()> {
     )
     .await?;
 
-    let models_with_capabilities = config
+    let models_with_modalities = config
         .service
         .models
         .iter()
-        .zip(config.service.capabilities.iter())
-        .map(|(model, capabilities)| {
-            let capabilities = capabilities.clone();
-            (model.clone(), capabilities)
+        .zip(config.service.modalities.iter())
+        .map(|(model, modalities)| {
+            let modalities = modalities.clone();
+            (model.clone(), modalities)
         })
         .collect();
 
@@ -211,7 +211,7 @@ async fn main() -> Result<()> {
     let proxy_service_state = ProxyServiceState {
         atoma_state: AtomaState::new_from_url(&config.state.database_url).await?,
         auth,
-        models_with_capabilities,
+        models_with_modalities,
     };
 
     let proxy_service_handle = spawn_with_shutdown(

--- a/atoma-proxy/src/server/config.rs
+++ b/atoma-proxy/src/server/config.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use atoma_proxy_service::ModelCapabilities;
+use atoma_proxy_service::ModelModality;
 use serde::Deserialize;
 
 use config::{Config, File};
@@ -28,11 +28,11 @@ pub struct AtomaServiceConfig {
     /// model that is currently supported by the Atoma Service.
     pub revisions: Vec<String>,
 
-    /// List of model capabilities.
+    /// List of model modalities.
     ///
-    /// This field contains a list of the associated model capabilities, for each
+    /// This field contains a list of the associated model modalities, for each
     /// model that is currently supported by the Atoma Service.
-    pub capabilities: Vec<Vec<ModelCapabilities>>,
+    pub modalities: Vec<Vec<ModelModality>>,
 
     /// Hugging face api token.
     ///

--- a/atoma-proxy/src/server/config.rs
+++ b/atoma-proxy/src/server/config.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use atoma_proxy_service::ModelCapabilities;
 use serde::Deserialize;
 
 use config::{Config, File};
@@ -26,6 +27,12 @@ pub struct AtomaServiceConfig {
     /// This field contains a list of the associated model revisions, for each
     /// model that is currently supported by the Atoma Service.
     pub revisions: Vec<String>,
+
+    /// List of model capabilities.
+    ///
+    /// This field contains a list of the associated model capabilities, for each
+    /// model that is currently supported by the Atoma Service.
+    pub capabilities: Vec<Vec<ModelCapabilities>>,
 
     /// Hugging face api token.
     ///

--- a/config.example.toml
+++ b/config.example.toml
@@ -22,7 +22,7 @@ models = [
   "meta-llama/Llama-3.2-1B-Instruct",
 ] # Models supported by proxy
 revisions = ["main", "main"] # Revision of the above models
-capabilities = [["Chat Completions"],["Chat Completions"]] # Capabilities of the above models
+modalities = [["Chat Completions"],["Chat Completions"]] # Modalities of the above models
 hf_token = "<API_KEY>" # Hugging face api token, required if you want to access a gated model
 
 [atoma_proxy_service]

--- a/config.example.toml
+++ b/config.example.toml
@@ -22,6 +22,7 @@ models = [
   "meta-llama/Llama-3.2-1B-Instruct",
 ] # Models supported by proxy
 revisions = ["main", "main"] # Revision of the above models
+capabilities = [["Chat Completions"],["Chat Completions"]] # Capabilities of the above models
 hf_token = "<API_KEY>" # Hugging face api token, required if you want to access a gated model
 
 [atoma_proxy_service]


### PR DESCRIPTION
Add model capabilities to proxy. This is for the example endpoint usage on the dashboard.