### PR TITLE
feat: digest table and multiple user with the same wallet

### DIFF
--- a/atoma-auth/src/sui/mod.rs
+++ b/atoma-auth/src/sui/mod.rs
@@ -427,7 +427,7 @@ impl Sui {
     ///
     /// # Returns
     ///
-    /// Returns a tuple containing the timestamp of the transaction and the balance changes
+    /// Returns the balance changes
     ///
     /// # Errors
     ///
@@ -437,7 +437,7 @@ impl Sui {
     pub async fn get_balance_changes(
         &self,
         transaction_digest: &str,
-    ) -> Result<(Option<u64>, Option<Vec<BalanceChange>>)> {
+    ) -> Result<Option<Vec<BalanceChange>>> {
         let transaction_digest = TransactionDigest::from_str(transaction_digest).unwrap();
         let client = self.wallet_ctx.get_client().await?;
         let transaction = client
@@ -450,6 +450,6 @@ impl Sui {
                 },
             )
             .await?;
-        Ok((transaction.timestamp_ms, transaction.balance_changes))
+        Ok(transaction.balance_changes)
     }
 }

--- a/atoma-state/src/handlers.rs
+++ b/atoma-state/src/handlers.rs
@@ -1147,24 +1147,18 @@ pub(crate) async fn handle_state_manager_event(
                 .send(sui_address)
                 .map_err(|_| AtomaStateManagerError::ChannelSendError)?;
         }
-        AtomaAtomaStateManagerEvent::GetUserId {
+        AtomaAtomaStateManagerEvent::ConfirmUser {
             sui_address,
+            user_id,
             result_sender,
         } => {
-            let user_id = state_manager.state.get_user_id(sui_address).await;
+            let confirmation = state_manager.state.confirm_user(sui_address, user_id).await;
             result_sender
-                .send(user_id)
+                .send(confirmation)
                 .map_err(|_| AtomaStateManagerError::ChannelSendError)?;
         }
-        AtomaAtomaStateManagerEvent::TopUpBalance {
-            user_id,
-            amount,
-            timestamp,
-        } => {
-            state_manager
-                .state
-                .top_up_balance(user_id, amount, timestamp)
-                .await?;
+        AtomaAtomaStateManagerEvent::TopUpBalance { user_id, amount } => {
+            state_manager.state.top_up_balance(user_id, amount).await?;
         }
         AtomaAtomaStateManagerEvent::DeductFromUsdc {
             user_id,
@@ -1172,6 +1166,18 @@ pub(crate) async fn handle_state_manager_event(
             result_sender,
         } => {
             let success = state_manager.state.deduct_from_usdc(user_id, amount).await;
+            result_sender
+                .send(success)
+                .map_err(|_| AtomaStateManagerError::ChannelSendError)?;
+        }
+        AtomaAtomaStateManagerEvent::InsertNewUsdcPaymentDigest {
+            digest,
+            result_sender,
+        } => {
+            let success = state_manager
+                .state
+                .insert_new_usdc_payment_digest(digest)
+                .await;
             result_sender
                 .send(success)
                 .map_err(|_| AtomaStateManagerError::ChannelSendError)?;

--- a/atoma-state/src/migrations/20250108091311_remove_wallet_constrain.sql
+++ b/atoma-state/src/migrations/20250108091311_remove_wallet_constrain.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_unique_sui_address;

--- a/atoma-state/src/migrations/20250108092319_add-usdc-digest-table.sql
+++ b/atoma-state/src/migrations/20250108092319_add-usdc-digest-table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE usdc_payment_digests (
+  digest TEXT PRIMARY KEY
+);
+
+ALTER TABLE balance
+DROP COLUMN usdc_last_timestamp;

--- a/atoma-state/src/types.rs
+++ b/atoma-state/src/types.rs
@@ -610,20 +610,22 @@ pub enum AtomaAtomaStateManagerEvent {
         result_sender: oneshot::Sender<Result<Option<String>>>,
     },
     /// Retrieves the user ID by Sui address
-    GetUserId {
+    ConfirmUser {
         sui_address: String,
-        result_sender: oneshot::Sender<Result<Option<i64>>>,
+        user_id: i64,
+        result_sender: oneshot::Sender<Result<bool>>,
     },
     /// Updates the balance of a user
-    TopUpBalance {
-        user_id: i64,
-        amount: i64,
-        timestamp: i64,
-    },
+    TopUpBalance { user_id: i64, amount: i64 },
     /// Withdraws the balance of a user
     DeductFromUsdc {
         user_id: i64,
         amount: i64,
+        result_sender: oneshot::Sender<Result<()>>,
+    },
+    /// Acknowledges a USDC payment. Fails if the digest has already been acknowledged.
+    InsertNewUsdcPaymentDigest {
+        digest: String,
         result_sender: oneshot::Sender<Result<()>>,
     },
 }


### PR DESCRIPTION
- Enable multiple users to have the same wallet.
- Get rid of the timestamp in the balance table.
- Introduce new table with the usdc digests. Each digest can be processed only once.