### PR TITLE
chore: change anyhow to custom error on auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,6 +584,7 @@ dependencies = [
  "shared-crypto 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.39.1)",
  "sui-keys",
  "sui-sdk",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]

--- a/atoma-auth/Cargo.toml
+++ b/atoma-auth/Cargo.toml
@@ -23,5 +23,6 @@ serde_json.workspace = true
 sui-keys.workspace = true
 shared-crypto.workspace = true
 sui-sdk.workspace = true
+thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/atoma-auth/src/lib.rs
+++ b/atoma-auth/src/lib.rs
@@ -2,6 +2,6 @@ mod auth;
 mod config;
 mod sui;
 
-pub use auth::Auth;
+pub use auth::{Auth, AuthError};
 pub use config::AtomaAuthConfig;
 pub use sui::{StackEntryResponse, Sui};

--- a/atoma-proxy-service/src/handlers/auth.rs
+++ b/atoma-proxy-service/src/handlers/auth.rs
@@ -1,3 +1,4 @@
+use atoma_auth::AuthError;
 use atoma_state::types::{
     AuthRequest, AuthResponse, ProofRequest, RevokeApiTokenRequest, UsdcPaymentRequest, UserProfile,
 };
@@ -260,7 +261,10 @@ pub(crate) async fn register(
         .await
         .map_err(|e| {
             error!("Failed to register user: {:?}", e);
-            StatusCode::INTERNAL_SERVER_ERROR
+            match e {
+                AuthError::UserAlreadyRegistered => StatusCode::CONFLICT,
+                _ => StatusCode::INTERNAL_SERVER_ERROR,
+            }
         })?;
     Ok(Json(AuthResponse {
         access_token,


### PR DESCRIPTION
This is for easier handling of the responses. E.g. user already registered now can throw 409 (conflict).