### PR TITLE
chore: change default stacks size to buy to 1M

### DIFF
--- a/atoma-proxy/src/server/handlers/nodes.rs
+++ b/atoma-proxy/src/server/handlers/nodes.rs
@@ -17,7 +17,7 @@ use utoipa::{OpenApi, ToSchema};
 
 use crate::server::error::AtomaProxyError;
 use crate::server::http_server::ProxyState;
-use crate::server::middleware::RequestMetadataExtension;
+use crate::server::middleware::{RequestMetadataExtension, STACK_SIZE_TO_BUY};
 
 pub const NODES_PATH: &str = "/v1/nodes";
 pub const NODES_CREATE_PATH: &str = "/v1/nodes";

--- a/atoma-proxy/src/server/handlers/nodes.rs
+++ b/atoma-proxy/src/server/handlers/nodes.rs
@@ -307,7 +307,7 @@ pub(crate) async fn nodes_models_retrieve(
                 .await
                 .acquire_new_stack_entry(
                     node.task_small_id as u64,
-                    node.max_num_compute_units as u64,
+                    STACK_SIZE_TO_BUY as u64,
                     node.price_per_one_million_compute_units as u64,
                 )
                 .await

--- a/atoma-proxy/src/server/middleware.rs
+++ b/atoma-proxy/src/server/middleware.rs
@@ -41,6 +41,8 @@ const MAX_BODY_SIZE: usize = 1024 * 1024; // 1MB
 
 const ONE_MILLION: i64 = 1_000_000;
 
+pub const STACK_SIZE_TO_BUY: i64 = 1_000_000;
+
 /// Metadata extension for tracking request-specific information about the selected inference node.
 ///
 /// This extension is attached to requests during authentication middleware processing
@@ -481,6 +483,7 @@ pub(crate) mod auth {
     };
 
     use super::ONE_MILLION;
+    use super::STACK_SIZE_TO_BUY;
 
     /// Represents the processed and validated request data after authentication and initial processing.
     ///
@@ -811,7 +814,7 @@ pub(crate) mod auth {
             state_manager_sender
                 .send(AtomaAtomaStateManagerEvent::DeductFromUsdc {
                     user_id,
-                    amount: node.price_per_one_million_compute_units * node.max_num_compute_units
+                    amount: node.price_per_one_million_compute_units * STACK_SIZE_TO_BUY
                         / ONE_MILLION,
                     result_sender,
                 })
@@ -839,7 +842,7 @@ pub(crate) mod auth {
                 .await
                 .acquire_new_stack_entry(
                     node.task_small_id as u64,
-                    node.max_num_compute_units as u64,
+                    STACK_SIZE_TO_BUY as u64,
                     node.price_per_one_million_compute_units as u64,
                 )
                 .await


### PR DESCRIPTION
Change the stacks size to buy to 1 million compute units.