### PR TITLE
feat: return proper login error

### DIFF
--- a/atoma-proxy-service/src/handlers/auth.rs
+++ b/atoma-proxy-service/src/handlers/auth.rs
@@ -309,8 +309,11 @@ pub(crate) async fn login(
         .check_user_password(&body.username, &body.password)
         .await
         .map_err(|e| {
-            error!("Failed to register user: {:?}", e);
-            StatusCode::INTERNAL_SERVER_ERROR
+            error!("Failed to login user: {:?}", e);
+            match e {
+                AuthError::PasswordNotValidOrUserNotFound => StatusCode::UNAUTHORIZED,
+                _ => StatusCode::INTERNAL_SERVER_ERROR,
+            }
         })?;
     Ok(Json(AuthResponse {
         access_token,

--- a/atoma-proxy/docs/openapi.yml
+++ b/atoma-proxy/docs/openapi.yml
@@ -393,6 +393,8 @@ paths:
           description: Failed to request node DH public key
         '503':
           description: No node found for model with confidential compute enabled for requested model
+      security:
+      - bearerAuth: []
 components:
   schemas:
     ChatCompletionChoice:


### PR DESCRIPTION
Return 401 if the user doesn't exist or the passwords doesn't match.