### PR TITLE
fix: update API URLs in README and OpenAPI documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository contains the proxy infrastructure that helps coordinate and opti
 Currently, the Atoma Proxy is powering Atoma's cloud web service, available at [cloud.atoma.network](https://cloud.atoma.network). By registering an account, you can obtain an API key and start using Atoma's AI services. For example, to request a chat completions from a `meta-llama/Llama-3.3-70B-Instruct` model, you can use the following request:
 
 ```bash
-curl -X POST https://api.atomacloud.com/v1/chat/completions \
+curl -X POST https://api.atoma.network/v1/chat/completions \
 -H "Authorization: Bearer YOUR_API_KEY" \
 -H "Content-Type: application/json" \
 -d '{

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repository contains the proxy infrastructure that helps coordinate and opti
 2. Contribute to the network's reliability and performance;
 3. Support the development of a more resilient and scalable AI infrastructure.
 
-Currently, the Atoma Proxy is powering Atoma's cloud web service, available at [atomacloud.com](https://atomacloud.com). By registering an account, you can obtain an API key and start using Atoma's AI services. For example, to request a chat completions from a `meta-llama/Llama-3.3-70B-Instruct` model, you can use the following request:
+Currently, the Atoma Proxy is powering Atoma's cloud web service, available at [cloud.atoma.network](https://cloud.atoma.network). By registering an account, you can obtain an API key and start using Atoma's AI services. For example, to request a chat completions from a `meta-llama/Llama-3.3-70B-Instruct` model, you can use the following request:
 
 ```bash
 curl -X POST https://api.atomacloud.com/v1/chat/completions \
@@ -37,7 +37,6 @@ curl -X POST https://api.atomacloud.com/v1/chat/completions \
 ```
 
 You can further deploy your own Atoma Proxy locally to power your own AI services. Please refer to the [Deployment Guide](#deploying-an-atoma-proxy) section for more information.
-
 
 ### Community Links
 
@@ -143,9 +142,9 @@ The deployment consists of two main services:
 #### Service URLs
 
 - Atoma Proxy: `http://localhost:8080` (configured via ATOMA_PROXY_PORT). This is the main service that you will use to interact with the Atoma Network, via an
-OpenAI-compatible API.
+  OpenAI-compatible API.
 - Atoma Proxy Service: `http://localhost:8081` (configured via ATOMA_SERVICE_PORT). You can use this URL to authenticate locally. If you plan to have a custom
-service (with custom domain), this service allows users to register, authenticate and get an API keys to the Atoma Proxy.
+  service (with custom domain), this service allows users to register, authenticate and get an API keys to the Atoma Proxy.
 
 #### Volume Mounts
 

--- a/atoma-proxy/docs/openapi.yml
+++ b/atoma-proxy/docs/openapi.yml
@@ -7,7 +7,7 @@ info:
     identifier: Apache-2.0
   version: 0.1.0
 servers:
-- url: https://api.atomacloud.com
+- url: https://api.atoma.network
 paths:
   /v1/chat/completions:
     post:

--- a/atoma-proxy/src/server/components/openapi.rs
+++ b/atoma-proxy/src/server/components/openapi.rs
@@ -56,7 +56,7 @@ pub fn openapi_routes() -> Router {
             (name = "Node Public Key Selection", description = "Node public key selection")
         ),
         servers(
-            (url = "https://api.atomacloud.com"),
+            (url = "https://api.atoma.network"),
         )
     )]
     struct ApiDoc;

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -46,7 +46,7 @@ services:
     networks:
       - atoma-network
     labels:
-      - "traefik.http.routers.traefik.rule=Host(`traefik.atomacloud.com`)"
+      - "traefik.http.routers.traefik.rule=Host(`traefik.atoma.network`)"
       - "traefik.http.routers.traefik.entrypoints=websecure"
       - "traefik.http.routers.traefik.tls.certresolver=myresolver"
       - "traefik.http.services.traefik.loadbalancer.server.port=8090"
@@ -80,12 +80,12 @@ services:
     <<: *atoma-proxy-base
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.api.rule=Host(`api.atomacloud.com`)"
+      - "traefik.http.routers.api.rule=Host(`api.atoma.network`)"
       - "traefik.http.routers.api.entrypoints=websecure"
       - "traefik.http.routers.api.tls.certresolver=myresolver"
       - "traefik.http.routers.api.service=api_service"
       - "traefik.http.services.api_service.loadbalancer.server.port=${ATOMA_API_SERVICE_PORT:-8080}"
-      - "traefik.http.routers.credentials.rule=Host(`credentials.atomacloud.com`)"
+      - "traefik.http.routers.credentials.rule=Host(`credentials.atoma.network`)"
       - "traefik.http.routers.credentials.entrypoints=websecure"
       - "traefik.http.routers.credentials.tls.certresolver=myresolver"
       - "traefik.http.routers.credentials.service=credentials_service"


### PR DESCRIPTION
- Changed the Atoma cloud service URL in README from `atomacloud.com` to `cloud.atoma.network`.
- Updated the OpenAPI documentation to reflect the new API URL from `https://api.atomacloud.com` to `https://api.atoma.network`.