### PR TITLE
feat: add x-speakeasy-sse-sentinel to OpenAPI documentation for chat …

### DIFF
--- a/atoma-proxy/docs/openapi.yml
+++ b/atoma-proxy/docs/openapi.yml
@@ -71,6 +71,7 @@ paths:
             text/event-stream:
               schema:
                 $ref: '#/components/schemas/ChatCompletionStreamResponse'
+              x-speakeasy-sse-sentinel: '[DONE]'
         '400':
           description: Bad request
         '401':


### PR DESCRIPTION
…completions stream

- Enhanced the OpenAPI specification by adding the x-speakeasy-sse-sentinel property with a value of '[DONE]' to the text/event-stream response of the /v1/chat/completions#stream endpoint.
- Updated the server component to modify the OpenAPI spec dynamically, ensuring the new property is included in the generated documentation.