### PR TITLE
fix: add google_client_id to config.example.toml

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -32,3 +32,4 @@ service_bind_address = "0.0.0.0:8081"
 secret_key = "secret_key" # Secret key for the tokens generation
 access_token_lifetime = 1 # In minutes
 refresh_token_lifetime = 1 # In days
+google_client_id="" # Google client id for google login


### PR DESCRIPTION
Add `google_client_id` to `config.example.toml`