### PR TITLE
feat: add cors layer to proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,6 +633,7 @@ dependencies = [
  "tokio",
  "tonic 0.9.2",
  "tower 0.5.2",
+ "tower-http 0.6.2",
  "tracing",
  "tracing-appender",
  "tracing-opentelemetry",
@@ -1439,7 +1440,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5819,7 +5820,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
@@ -9459,7 +9460,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/atoma-proxy/Cargo.toml
+++ b/atoma-proxy/Cargo.toml
@@ -21,6 +21,14 @@ fastcrypto.workspace = true
 flume.workspace = true
 futures = { workspace = true }
 hf-hub = { workspace = true }
+once_cell = "1.20"
+opentelemetry = { version = "0.21", features = ["trace"] }
+opentelemetry_sdk = { version = "0.21", features = ["rt-tokio", "trace"] }
+opentelemetry-otlp = { version = "0.14", features = [
+    "grpc-tonic",
+    "trace",
+    "tls",
+] }
 rand = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true, features = ["derive"] }
@@ -30,28 +38,21 @@ sqlx.workspace = true
 sui-keys.workspace = true
 sui-sdk.workspace = true
 thiserror = { workspace = true }
+tokenizers.workspace = true
 tokio = { workspace = true, features = ["full"] }
+tonic = { version = "0.9", features = ["tls", "tls-roots", "prost"] }
+tower = { workspace = true }
+tower-http = { workspace = true, features = ["cors"] }
 tracing-appender.workspace = true
+tracing-opentelemetry = "0.22"
 tracing-subscriber = { workspace = true, features = [
     "env-filter",
     "json",
     "time",
 ] }
 tracing.workspace = true
-tokenizers.workspace = true
-tower = { workspace = true }
 utoipa = { workspace = true, features = ["axum_extras", "preserve_path_order"] }
 utoipa-swagger-ui = { workspace = true, features = ["axum"] }
-opentelemetry = { version = "0.21", features = ["trace"] }
-opentelemetry_sdk = { version = "0.21", features = ["rt-tokio", "trace"] }
-opentelemetry-otlp = { version = "0.14", features = [
-    "grpc-tonic",
-    "trace",
-    "tls",
-] }
-tonic = { version = "0.9", features = ["tls", "tls-roots", "prost"] }
-once_cell = "1.20"
-tracing-opentelemetry = "0.22"
 
 [features]
 google-oauth = ["atoma-auth/google-oauth", "atoma-proxy-service/google-oauth"]

--- a/atoma-proxy/docs/openapi.yml
+++ b/atoma-proxy/docs/openapi.yml
@@ -340,8 +340,6 @@ paths:
                 $ref: '#/components/schemas/ModelList'
         '500':
           description: Failed to retrieve list of available models
-      security:
-      - bearerAuth: []
   /v1/nodes:
     post:
       tags:

--- a/atoma-proxy/src/server/handlers/models.rs
+++ b/atoma-proxy/src/server/handlers/models.rs
@@ -28,9 +28,6 @@ pub struct ModelsOpenApi;
 #[utoipa::path(
     get,
     path = "",
-    security(
-        ("bearerAuth" = [])
-    ),
     responses(
         (status = OK, description = "List of available models", body = ModelList),
         (status = INTERNAL_SERVER_ERROR, description = "Failed to retrieve list of available models")

--- a/atoma-proxy/src/server/http_server.rs
+++ b/atoma-proxy/src/server/http_server.rs
@@ -10,12 +10,14 @@ use axum::{
 };
 
 use flume::Sender;
+use reqwest::Method;
 use serde::Serialize;
 
 use tokenizers::Tokenizer;
 use tokio::sync::watch;
 use tokio::{net::TcpListener, sync::RwLock};
 use tower::ServiceBuilder;
+use tower_http::cors::{Any, CorsLayer};
 use tracing::instrument;
 
 pub use components::openapi::openapi_routes;
@@ -173,6 +175,11 @@ pub fn create_router(state: &ProxyState) -> Router {
         )))
         .with_state(state.clone());
 
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods(vec![Method::GET, Method::POST])
+        .allow_headers(Any);
+
     Router::new()
         .route(CHAT_COMPLETIONS_PATH, post(chat_completions_create))
         .route(EMBEDDINGS_PATH, post(embeddings_create))
@@ -189,6 +196,7 @@ pub fn create_router(state: &ProxyState) -> Router {
         .route(HEALTH_PATH, get(health))
         .merge(confidential_router)
         .merge(openapi_routes())
+        .layer(cors)
 }
 
 /// Starts the atoma proxy server.


### PR DESCRIPTION
Add cors layer to proxy, so it can be fetched from frontends.
Remove requirements for bearer token from `/v1/models` endpoint.