### PR TITLE
build: update `Dockerfile` to use ubuntu for builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN if [ "$PROFILE" = "cloud" ]; then \
     fi
 
 # Final stage
-FROM --platform=$TARGETPLATFORM debian:bullseye-slim
+FROM ubuntu:24.04
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder stage
-FROM --platform=$BUILDPLATFORM rust:1.83-slim-bullseye AS builder
+FROM --platform=$BUILDPLATFORM ubuntu:24.04 AS builder
 
 # Add platform-specific arguments
 ARG TARGETPLATFORM
@@ -15,8 +15,16 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     pkg-config \
     libssl-dev \
+    libssl3 \
     curl \
     && rm -rf /var/lib/apt/lists/*
+
+# Install Rust 1.84.0
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.84.0 \
+    && . "$HOME/.cargo/env"
+
+# Add cargo to PATH
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 WORKDIR /usr/src/atoma-proxy
 
@@ -36,7 +44,7 @@ FROM --platform=$TARGETPLATFORM debian:bullseye-slim
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y \
     ca-certificates \
-    libssl1.1 \
+    libssl3 \
     libpq5 \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Similar fixes to https://github.com/atoma-network/atoma-node/pull/431 which were required in order to build the failing [docker image build](https://github.com/atoma-network/atoma-proxy/actions/runs/13437149673)