### PR TITLE
feat: add name to api token

### DIFF
--- a/atoma-auth/src/auth.rs
+++ b/atoma-auth/src/auth.rs
@@ -1106,6 +1106,7 @@ active_address: "0x939cfcc7fcbc71ce983203bcb36fa498901932ab9293dfa2b271203e71603
                 AtomaAtomaStateManagerEvent::StoreNewApiToken {
                     user_id: event_user_id,
                     api_token: _api_token,
+                    name: _name,
                 } => {
                     assert_eq!(event_user_id, user_id);
                     // assert_eq!(event_api_token, api_token);
@@ -1124,7 +1125,10 @@ active_address: "0x939cfcc7fcbc71ce983203bcb36fa498901932ab9293dfa2b271203e71603
         assert_eq!(claims.user_id, user_id);
         assert!(claims.refresh_token_hash.is_some());
         // Generate api token
-        let _api_token = auth.generate_api_token(&access_token).await.unwrap();
+        let _api_token = auth
+            .generate_api_token(&access_token, "test".to_string())
+            .await
+            .unwrap();
         if tokio::time::timeout(std::time::Duration::from_secs(1), mock_handle)
             .await
             .is_err()

--- a/atoma-auth/src/auth.rs
+++ b/atoma-auth/src/auth.rs
@@ -6,7 +6,10 @@ use std::{str::FromStr, sync::Arc};
 use crate::google::{self, fetch_google_public_keys};
 use crate::{AtomaAuthConfig, Sui};
 use anyhow::anyhow;
-use atoma_state::{types::AtomaAtomaStateManagerEvent, AtomaStateManagerError};
+use atoma_state::{
+    types::{AtomaAtomaStateManagerEvent, TokenResponse},
+    AtomaStateManagerError,
+};
 use atoma_utils::hashing::blake2b_hash;
 use blake2::{
     digest::{consts::U32, generic_array::GenericArray},
@@ -401,12 +404,13 @@ impl Auth {
     /// # Arguments
     ///
     /// * `jwt` - The access token to be used to generate the API token
+    /// * `name` - The name of the API token
     ///
     /// # Returns
     ///
     /// * `Result<String>` - The generated API token
     #[instrument(level = "info", skip(self))]
-    pub async fn generate_api_token(&self, jwt: &str) -> Result<String> {
+    pub async fn generate_api_token(&self, jwt: &str, name: String) -> Result<String> {
         let claims = self.get_claims_from_token(jwt).await?;
         let api_token: String = rand::thread_rng()
             .sample_iter(&rand::distributions::Alphanumeric)
@@ -417,6 +421,7 @@ impl Auth {
             .send(AtomaAtomaStateManagerEvent::StoreNewApiToken {
                 user_id: claims.user_id,
                 api_token: api_token.clone(),
+                name,
             })?;
         Ok(api_token)
     }
@@ -434,12 +439,12 @@ impl Auth {
     ///
     /// * `Result<()>` - If the API token was revoked
     #[instrument(level = "info", skip(self))]
-    pub async fn revoke_api_token(&self, jwt: &str, api_token: &str) -> Result<()> {
+    pub async fn revoke_api_token(&self, jwt: &str, api_token_id: i64) -> Result<()> {
         let claims = self.get_claims_from_token(jwt).await?;
         self.state_manager_sender
             .send(AtomaAtomaStateManagerEvent::RevokeApiToken {
                 user_id: claims.user_id,
-                api_token: api_token.to_string(),
+                api_token_id,
             })?;
         Ok(())
     }
@@ -456,7 +461,7 @@ impl Auth {
     ///
     /// * `Result<Vec<String>>` - The list of API tokens
     #[instrument(level = "info", skip(self))]
-    pub async fn get_all_api_tokens(&self, jwt: &str) -> Result<Vec<String>> {
+    pub async fn get_all_api_tokens(&self, jwt: &str) -> Result<Vec<TokenResponse>> {
         let claims = self.get_claims_from_token(jwt).await?;
 
         let (result_sender, result_receiver) = oneshot::channel();

--- a/atoma-proxy-service/docs/openapi.yml
+++ b/atoma-proxy-service/docs/openapi.yml
@@ -25,7 +25,7 @@ paths:
         '500':
           description: Service is unhealthy
   /generate_api_token:
-    get:
+    post:
       tags:
       - Auth
       summary: Generates an API token for the user.
@@ -39,6 +39,12 @@ paths:
 
         * `Result<Json<String>>` - A JSON response containing the generated API token
       operationId: generate_api_token
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateTokenRequest'
+        required: true
       responses:
         '200':
           description: Generates an API token for the user
@@ -648,6 +654,17 @@ components:
         username:
           type: string
           description: The user's unique identifier
+    CreateTokenRequest:
+      type: object
+      description: |-
+        Request payload for creating a new API token
+
+        Contains the name of the token
+      required:
+      - name
+      properties:
+        name:
+          type: string
     ProofRequest:
       type: object
       description: |-
@@ -659,14 +676,16 @@ components:
       properties:
         signature:
           type: string
+          description: The signature of the user to prove ownership of the sui address
     RevokeApiTokenRequest:
       type: object
       description: Request payload for revoking an API token
       required:
-      - api_token
+      - api_token_id
       properties:
-        api_token:
-          type: string
+        api_token_id:
+          type: integer
+          format: int64
           description: The API token to be revoked
     UsdcPaymentRequest:
       type: object
@@ -681,8 +700,10 @@ components:
           type:
           - string
           - 'null'
+          description: The proof signature of the payment
         transaction_digest:
           type: string
+          description: The transaction digest of the payment
   securitySchemes:
     bearerAuth:
       type: http

--- a/atoma-state/build.rs
+++ b/atoma-state/build.rs
@@ -1,0 +1,9 @@
+use std::path::Path;
+
+fn main() {
+    let migrations_path = Path::new("src/migrations");
+
+    if migrations_path.exists() {
+        println!("cargo:rerun-if-changed=src/migrations");
+    }
+}

--- a/atoma-state/src/handlers.rs
+++ b/atoma-state/src/handlers.rs
@@ -1304,16 +1304,23 @@ pub async fn handle_state_manager_event(
                 .send(user_id)
                 .map_err(|_| AtomaStateManagerError::ChannelSendError)?;
         }
-        AtomaAtomaStateManagerEvent::StoreNewApiToken { user_id, api_token } => {
+        AtomaAtomaStateManagerEvent::StoreNewApiToken {
+            user_id,
+            api_token,
+            name,
+        } => {
             state_manager
                 .state
-                .store_api_token(user_id, &api_token)
+                .store_api_token(user_id, &api_token, &name)
                 .await?;
         }
-        AtomaAtomaStateManagerEvent::RevokeApiToken { user_id, api_token } => {
+        AtomaAtomaStateManagerEvent::RevokeApiToken {
+            user_id,
+            api_token_id,
+        } => {
             state_manager
                 .state
-                .delete_api_token(user_id, &api_token)
+                .delete_api_token(user_id, api_token_id)
                 .await?;
         }
         AtomaAtomaStateManagerEvent::GetApiTokensForUser {

--- a/atoma-state/src/migrations/20250304082533_api_token_name.sql
+++ b/atoma-state/src/migrations/20250304082533_api_token_name.sql
@@ -1,0 +1,11 @@
+-- This migration adds a name column to the api_tokens table.
+-- This column will be used to store the last 4 characters of the token for the existing tokens.
+ALTER TABLE api_tokens
+ADD COLUMN name TEXT DEFAULT 'temporary default';
+
+UPDATE api_tokens
+SET name = RIGHT(token, 4);
+
+ALTER TABLE api_tokens
+ALTER COLUMN name SET NOT NULL,
+ALTER COLUMN name DROP DEFAULT;

--- a/atoma-state/src/migrations/20250304134031_fix-timestamps.sql
+++ b/atoma-state/src/migrations/20250304134031_fix-timestamps.sql
@@ -1,0 +1,26 @@
+-- Rename column creation_timestamp to old_creation_timestamp in users table
+ALTER TABLE users RENAME COLUMN creation_timestamp TO old_creation_timestamp;
+
+-- Add new column creation_timestamp with default value CURRENT_TIMESTAMP in users table
+ALTER TABLE users ADD COLUMN creation_timestamp TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;
+
+-- Update the new column creation_timestamp with the value of old_creation_timestamp in users table
+UPDATE users SET creation_timestamp = old_creation_timestamp;
+
+-- Drop column old_creation_timestamp in users table
+ALTER TABLE users DROP COLUMN old_creation_timestamp;
+
+-- Rename column creation_timestamp to old_creation_timestamp in api_tokens table
+ALTER TABLE api_tokens RENAME COLUMN creation_timestamp TO old_creation_timestamp;
+
+-- Add new column creation_timestamp with default value CURRENT_TIMESTAMP in api_tokens table
+ALTER TABLE api_tokens ADD COLUMN creation_timestamp TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;
+
+-- Update the new column creation_timestamp with the value of old_creation_timestamp in api_tokens table
+UPDATE api_tokens SET creation_timestamp = old_creation_timestamp;
+
+-- Drop column old_creation_timestamp in api_tokens table
+ALTER TABLE api_tokens DROP COLUMN old_creation_timestamp;
+
+-- Add creation_timestamp column to nodes table
+ALTER TABLE nodes ADD COLUMN creation_timestamp TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;

--- a/atoma-state/src/types.rs
+++ b/atoma-state/src/types.rs
@@ -24,8 +24,8 @@ pub enum Modalities {
 /// Request payload for revoking an API token
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct RevokeApiTokenRequest {
-    /// The API token to be revoked
-    pub api_token: String,
+    /// The API token id to be revoked
+    pub api_token_id: i64,
 }
 
 /// Request payload for user authentication
@@ -48,6 +48,30 @@ pub struct AuthResponse {
     pub access_token: String,
     /// Long-lived token used to obtain new access tokens
     pub refresh_token: String,
+}
+
+/// Request payload for creating a new API token
+///
+/// Contains the name of the token
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct CreateTokenRequest {
+    /// The name of the token
+    pub name: String,
+}
+
+/// After requesting api tokens vec of these will be returned
+///
+/// Contains the id of the token, the last 4 digits of the token, the name of the token and the creation date of the token
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, FromRow)]
+pub struct TokenResponse {
+    /// The id of the token
+    pub id: i64,
+    /// The last 4 chars of the token
+    pub token_last_4: String,
+    /// The creation timestamp of the token
+    pub created_at: DateTime<Utc>,
+    /// The name of the token
+    pub name: String,
 }
 
 /// Request payload for updating the sui address for the user.
@@ -797,8 +821,8 @@ pub enum AtomaAtomaStateManagerEvent {
     RevokeApiToken {
         /// The user ID
         user_id: i64,
-        /// The API token
-        api_token: String,
+        /// The API token id
+        api_token_id: i64,
     },
     /// Stores a new API token for a user
     StoreNewApiToken {
@@ -806,6 +830,8 @@ pub enum AtomaAtomaStateManagerEvent {
         user_id: i64,
         /// The API token
         api_token: String,
+        /// Name of the token
+        name: String,
     },
     /// Retrieves all API tokens for a user
     GetApiTokensForUser {
@@ -813,7 +839,7 @@ pub enum AtomaAtomaStateManagerEvent {
         user_id: i64,
         /// Channel to send back the list of API tokens
         /// Returns Ok(Vec<String>) with the list of API tokens or an error if the query fails
-        result_sender: oneshot::Sender<Result<Vec<String>>>,
+        result_sender: oneshot::Sender<Result<Vec<TokenResponse>>>,
     },
     /// Stores the sui_address with proven ownership
     UpdateSuiAddress {


### PR DESCRIPTION
- Add name to api tokens.
  - change the create from get to post, add name to the request
  - change the request from revoking from api token to id of the token
- Make the timestamp types the same for users and nodes.