### PR TITLE
feat: return 0 balance when user is not found

### DIFF
--- a/atoma-state/src/state_manager.rs
+++ b/atoma-state/src/state_manager.rs
@@ -3982,10 +3982,11 @@ impl AtomaState {
     pub async fn get_balance_for_user(&self, user_id: i64) -> Result<i64> {
         let balance = sqlx::query("SELECT usdc_balance FROM balance WHERE user_id = $1")
             .bind(user_id)
-            .fetch_one(&self.db)
-            .await?;
+            .fetch_optional(&self.db)
+            .await?
+            .map_or(0, |row| row.get::<i64, _>("usdc_balance"));
 
-        Ok(balance.get::<i64, _>("usdc_balance"))
+        Ok(balance)
     }
 
     /// Get the user profile by user_id.


### PR DESCRIPTION
Before the non existing user was handled in the frontend, let just return 0 for non-existing user here to simplify the frontend.
Non-existing user means the user had not yet topped up his account. But the users exists because this function is behind auth.