### PR TITLE
feat: add last used timestamp for tokens

### DIFF
--- a/atoma-state/src/migrations/20250317104814_api_token_last_used_timestamp.sql
+++ b/atoma-state/src/migrations/20250317104814_api_token_last_used_timestamp.sql
@@ -1,0 +1,2 @@
+ALTER TABLE api_tokens
+ADD COLUMN last_used_timestamp TIMESTAMPTZ;

--- a/atoma-state/src/types.rs
+++ b/atoma-state/src/types.rs
@@ -77,6 +77,8 @@ pub struct TokenResponse {
     pub id: i64,
     /// The last 4 chars of the token
     pub token_last_4: String,
+    /// The last used timestamp of the token
+    pub last_used_timestamp: Option<DateTime<Utc>>,
     /// The creation timestamp of the token
     pub created_at: DateTime<Utc>,
     /// The name of the token


### PR DESCRIPTION
Whenever the api tokens is checked for validity, we count it as used and modify the timestamp.