### PR TITLE
feat: add interval to grafana query

### DIFF
--- a/atoma-proxy-service/src/components/grafana.rs
+++ b/atoma-proxy-service/src/components/grafana.rs
@@ -48,6 +48,8 @@ struct Panel {
     /// The fields config
     #[serde(rename = "fieldConfig")]
     field_config: FieldsConfig,
+    /// Interval set in grafana
+    interval: Option<String>,
 }
 
 /// The inner dashboard struct from grafana, but incomplete, because we don't care about everything.
@@ -98,6 +100,7 @@ impl From<Dashboard> for Vec<PanelResponse> {
                 title: panel.title,
                 description: panel.description,
                 unit: panel.field_config.defaults.unit,
+                interval: panel.interval,
                 query: Query {
                     queries: panel.targets,
                     from: from.clone(),

--- a/atoma-proxy-service/src/handlers/stats.rs
+++ b/atoma-proxy-service/src/handlers/stats.rs
@@ -30,6 +30,8 @@ pub struct PanelResponse {
     pub unit: Option<String>,
     /// The query for the panel.
     pub query: grafana::Query,
+    /// The interval of the panel.
+    pub interval: Option<String>,
 }
 
 /// Dashboard response is part of the GraphsResponse.


### PR DESCRIPTION
Add interval to grafana query, the interval needs to be set on dashboard to return the proper interval, it's not part of the query itself (that's how grafana do it).