### PR TITLE
feat: change the estimated metrics to the real value

### DIFF
--- a/atoma-proxy/src/server/handlers/chat_completions.rs
+++ b/atoma-proxy/src/server/handlers/chat_completions.rs
@@ -591,7 +591,10 @@ async fn handle_non_streaming_response(
         .map_or(0, |n| n as i64);
 
     // Record the total tokens in the chat completions total tokens metric
-    CHAT_COMPLETIONS_TOTAL_TOKENS.add(total_tokens, &[KeyValue::new("model", model_name.clone())]);
+    CHAT_COMPLETIONS_TOTAL_TOKENS.add(
+        total_tokens as u64,
+        &[KeyValue::new("model", model_name.clone())],
+    );
 
     let verify_hash = endpoint != CONFIDENTIAL_CHAT_COMPLETIONS_PATH;
     verify_response_hash_and_signature(&response.0, verify_hash)?;

--- a/atoma-proxy/src/server/handlers/metrics.rs
+++ b/atoma-proxy/src/server/handlers/metrics.rs
@@ -163,9 +163,9 @@ pub static TEXT_EMBEDDINGS_LATENCY_METRICS: Lazy<Histogram<f64>> = Lazy::new(|| 
 /// - Labels:
 ///   - `model`: The model used for completion
 /// - Unit: tokens (count)
-pub static CHAT_COMPLETIONS_ESTIMATED_TOTAL_TOKENS: Lazy<Counter<u64>> = Lazy::new(|| {
+pub static CHAT_COMPLETIONS_TOTAL_TOKENS: Lazy<Counter<u64>> = Lazy::new(|| {
     GLOBAL_METER
-        .u64_counter("atoma_chat_completions_estimated_total_tokens")
+        .u64_counter("atoma_chat_completions_total_tokens")
         .with_description("The estimated total number of tokens processed")
         .with_unit("tokens")
         .build()

--- a/atoma-proxy/src/server/streamer.rs
+++ b/atoma-proxy/src/server/streamer.rs
@@ -199,8 +199,10 @@ impl Streamer {
             })?;
 
         // Record the total tokens in the chat completions total tokens metric
-        CHAT_COMPLETIONS_TOTAL_TOKENS
-            .add(total_tokens, &[KeyValue::new("model", model_name.clone())]);
+        CHAT_COMPLETIONS_TOTAL_TOKENS.add(
+            total_tokens as u64,
+            &[KeyValue::new("model", self.model_name.clone())],
+        );
 
         // Update the nodes throughput performance
         if let Err(e) = self.state_manager_sender.send(

--- a/atoma-proxy/src/server/streamer.rs
+++ b/atoma-proxy/src/server/streamer.rs
@@ -22,6 +22,7 @@ use crate::server::handlers::{chat_completions::CHAT_COMPLETIONS_PATH, update_st
 use super::handlers::chat_completions::CONFIDENTIAL_CHAT_COMPLETIONS_PATH;
 use super::handlers::metrics::{
     CHAT_COMPLETIONS_INTER_TOKEN_GENERATION_TIME, CHAT_COMPLETIONS_TIME_TO_FIRST_TOKEN,
+    CHAT_COMPLETIONS_TOTAL_TOKENS,
 };
 use super::handlers::verify_response_hash_and_signature;
 
@@ -196,6 +197,10 @@ impl Streamer {
                 );
                 Error::new("Error getting total tokens from usage")
             })?;
+
+        // Record the total tokens in the chat completions total tokens metric
+        CHAT_COMPLETIONS_TOTAL_TOKENS
+            .add(total_tokens, &[KeyValue::new("model", model_name.clone())]);
 
         // Update the nodes throughput performance
         if let Err(e) = self.state_manager_sender.send(


### PR DESCRIPTION
We had metric for estimated tokens which feels kind of useless, because that's just the input size + max output length of model. I changed it to capture the total tokens from the inference results.