### PR TITLE
chore: use env variable to set logging levels

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,6 @@ POSTGRES_PORT=5432
 # This is used in the Github Actions to map the port to the postgres container
 POSTGRES_INTERNAL_PORT=5432
 
-TRACE_LEVEL=info
 ATOMA_PROXY_CONFIG_PATH=./config.toml
 
 # Cursor toml file path
@@ -32,8 +31,6 @@ ATOMA_P2P_SERVICE_PORT=8083
 # ZkLogin Prover
 ZKEY= # Path to the zkey file
 
-# Tracing level
-TRACE_LEVEL=info
 
 # Prometheus Configuration
 PROMETHEUS_PORT=9090

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 ARG TARGETARCH
 
-# Trace level argument
-ARG TRACE_LEVEL
 ARG PROFILE
 
 # Install build dependencies
@@ -33,9 +31,9 @@ COPY . .
 
 # Compile
 RUN if [ "$PROFILE" = "cloud" ]; then \
-    RUST_LOG=${TRACE_LEVEL} cargo build --release --bin atoma-proxy --features google-oauth; \
+    cargo build --release --bin atoma-proxy --features google-oauth; \
     else \
-    RUST_LOG=${TRACE_LEVEL} cargo build --release --bin atoma-proxy; \
+    cargo build --release --bin atoma-proxy; \
     fi
 
 # Final stage

--- a/README.md
+++ b/README.md
@@ -209,6 +209,10 @@ docker compose --profile cloud up -d --build
 ATOMA_LOG_LEVELS=atoma_p2p=info,debug docker compose --profile local up -d --build
 ```
 
+Some examples for the ATOMA_LOG_LEVELS
+- `info,atoma_p2p=off,libp2p_mdns=off,opentelemetry_sdk=off,quinn_udp=off,tracing_loki=off` - no p2p/metrics logs
+- `info,sqlx=debug` for showing the sql queries
+
 #### Container Architecture
 
 The deployment consists of two main services:

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ git clone https://github.com/atoma-network/atoma-proxy.git
 cd atoma-proxy
 ```
 
-2. Configure environment variables by creating `.env` file. Please ensure you have created the requisite user and database in your postgres instance. Once you've done that, you can use `.env.example` as template for your `.env` file.
+1. Configure environment variables by creating `.env` file. Please ensure you have created the requisite user and database in your postgres instance. Once you've done that, you can use `.env.example` as template for your `.env` file.
 
 ```bash
 cp .env.example .env
@@ -88,54 +88,52 @@ Please ensure you have created the requisite user and database in your postgres 
 POSTGRES_DB=<YOUR_DB_NAME>
 POSTGRES_USER=<YOUR_DB_USER>
 POSTGRES_PASSWORD=<YOUR_DB_PASSWORD>
-
-TRACE_LEVEL=info
 ```
 
-3. Configure `config.toml`, using `config.example.toml` as template.
+1. Configure `config.toml`, using `config.example.toml` as template.
 
 ## Configuration Reference
 
 ### Sui Configuration (`[atoma_sui]`)
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `http_rpc_node_addr` | Sui RPC node endpoint for testnet network | `https://fullnode.testnet.sui.io:443` |
-| `atoma_db` | ATOMA database object ID on testnet | `0x741693...` |
-| `atoma_package_id` | ATOMA smart contract package ID on testnet | `0x0c4a52...` |
-| `usdc_package_id` | USDC smart contract package ID on testnet | `0xa1ec7f...` |
-| `request_timeout` | Maximum time to wait for RPC requests | `300 seconds` |
-| `max_concurrent_requests` | Maximum number of simultaneous RPC requests | `10` |
-| `limit` | Maximum number of items per page for paginated responses | `100` |
-| `sui_config_path` | Path to Sui client configuration file | `/root/.sui/sui_config/client.yaml` |
-| `sui_keystore_path` | Path to Sui keystore containing account keys | `/root/.sui/sui_config/sui.keystore` |
-| `cursor_path` | Path to store the event cursor state | `./cursor.toml` |
+| Parameter                 | Description                                              | Default                               |
+| ------------------------- | -------------------------------------------------------- | ------------------------------------- |
+| `http_rpc_node_addr`      | Sui RPC node endpoint for testnet network                | `https://fullnode.testnet.sui.io:443` |
+| `atoma_db`                | ATOMA database object ID on testnet                      | `0x741693...`                         |
+| `atoma_package_id`        | ATOMA smart contract package ID on testnet               | `0x0c4a52...`                         |
+| `usdc_package_id`         | USDC smart contract package ID on testnet                | `0xa1ec7f...`                         |
+| `request_timeout`         | Maximum time to wait for RPC requests                    | `300 seconds`                         |
+| `max_concurrent_requests` | Maximum number of simultaneous RPC requests              | `10`                                  |
+| `limit`                   | Maximum number of items per page for paginated responses | `100`                                 |
+| `sui_config_path`         | Path to Sui client configuration file                    | `/root/.sui/sui_config/client.yaml`   |
+| `sui_keystore_path`       | Path to Sui keystore containing account keys             | `/root/.sui/sui_config/sui.keystore`  |
+| `cursor_path`             | Path to store the event cursor state                     | `./cursor.toml`                       |
 
 ### State Configuration (`[atoma_state]`)
-| Parameter | Description | Example |
-|-----------|-------------|---------|
+| Parameter      | Description                                              | Example                                                                  |
+| -------------- | -------------------------------------------------------- | ------------------------------------------------------------------------ |
 | `database_url` | PostgreSQL connection string (must match values in .env) | `postgresql://<POSTGRES_USER>:<POSTGRES_PASSWORD>@db:5432/<POSTGRES_DB>` |
 
 ### Service Configuration (`[atoma_service]`)
-| Parameter | Description | Example |
-|-----------|-------------|---------|
-| `service_bind_address` | HTTP service binding address and port | `0.0.0.0:8080` |
-| `password` | Authentication password for the service API | `password` |
-| `models` | List of supported LLM models | `["meta-llama/Llama-3.3-70B-Instruct"]` |
-| `revisions` | Model revision/version tags | `["main"]` |
-| `hf_token` | Hugging Face API token for gated/private models | Required |
+| Parameter              | Description                                     | Example                                 |
+| ---------------------- | ----------------------------------------------- | --------------------------------------- |
+| `service_bind_address` | HTTP service binding address and port           | `0.0.0.0:8080`                          |
+| `password`             | Authentication password for the service API     | `password`                              |
+| `models`               | List of supported LLM models                    | `["meta-llama/Llama-3.3-70B-Instruct"]` |
+| `revisions`            | Model revision/version tags                     | `["main"]`                              |
+| `hf_token`             | Hugging Face API token for gated/private models | Required                                |
 
 ### Proxy Service Configuration (`[atoma_proxy_service]`)
-| Parameter | Description | Default |
-|-----------|-------------|---------|
+| Parameter              | Description                            | Default        |
+| ---------------------- | -------------------------------------- | -------------- |
 | `service_bind_address` | Proxy service binding address and port | `0.0.0.0:8081` |
 
 ### Authentication Configuration (`[atoma_auth]`)
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `secret_key` | JWT signing key for token generation | `secret_key` |
-| `access_token_lifetime` | Access token validity duration in minutes | `1` |
-| `refresh_token_lifetime` | Refresh token validity duration in days | `1` |
-| `google_client_id` | Google OAuth client ID (required for google-oauth feature) | `""` |
+| Parameter                | Description                                                | Default      |
+| ------------------------ | ---------------------------------------------------------- | ------------ |
+| `secret_key`             | JWT signing key for token generation                       | `secret_key` |
+| `access_token_lifetime`  | Access token validity duration in minutes                  | `1`          |
+| `refresh_token_lifetime` | Refresh token validity duration in days                    | `1`          |
+| `google_client_id`       | Google OAuth client ID (required for google-oauth feature) | `""`         |
 
 ### Example Configuration
 
@@ -203,6 +201,12 @@ docker compose --profile cloud up --build
 
 # Or run in detached mode
 docker compose --profile cloud up -d --build
+```
+
+1. The deployment defaults to `info` level logs, in order to change the log level upon deployment, you can run set the `ATOMA_LOG_LEVELS` env variable at runtime.
+
+```bash
+ATOMA_LOG_LEVELS=atoma_p2p=info,debug docker compose --profile local up -d --build
 ```
 
 #### Container Architecture

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -3,8 +3,6 @@ x-atoma-proxy-base: &atoma-proxy-base
   build: &atoma-proxy-base-build
     context: .
     dockerfile: Dockerfile
-    args: &atoma-proxy-base-build-args
-      TRACE_LEVEL: ${TRACE_LEVEL:-info}
   env_file:
     - .env
   volumes:
@@ -76,7 +74,6 @@ services:
     build:
       <<: *atoma-proxy-base-build
       args:
-        <<: *atoma-proxy-base-build-args
         PROFILE: local
     ports:
       - "${ATOMA_SERVICE_PORT:-8080}:8080"
@@ -90,7 +87,6 @@ services:
     build:
       <<: *atoma-proxy-base-build
       args:
-        <<: *atoma-proxy-base-build-args
         PROFILE: cloud
     labels:
       - "traefik.enable=true"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,8 +3,6 @@ x-atoma-proxy-base: &atoma-proxy-base
   build: &atoma-proxy-base-build
     context: .
     dockerfile: Dockerfile
-    args: &atoma-proxy-base-build-args
-      TRACE_LEVEL: ${TRACE_LEVEL:-info}
   volumes:
     - ${CONFIG_PATH:-./config.toml}:/app/config.toml
     - ./logs:/app/logs
@@ -15,7 +13,7 @@ x-atoma-proxy-base: &atoma-proxy-base
     - .env
   environment:
     - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
-    - RUST_LOG=${ATOMA_P2P_LOG_LEVEL:-atoma_p2p=info,atoma_daemon=info}
+    - RUST_LOG=${ATOMA_LOG_LEVELS:-info}
   depends_on:
     db:
       condition: service_healthy
@@ -83,7 +81,6 @@ services:
     build:
       <<: *atoma-proxy-base-build
       args:
-        <<: *atoma-proxy-base-build-args
         PROFILE: local
     ports:
       - "${ATOMA_SERVICE_PORT:-8080}:8080"
@@ -98,7 +95,6 @@ services:
     build:
       <<: *atoma-proxy-base-build
       args:
-        <<: *atoma-proxy-base-build-args
         PROFILE: cloud
     ports:
       - "${ATOMA_P2P_PORT:-8083}:8083/udp"


### PR DESCRIPTION
Docker builds can now be deployed using the `ATOMA_LOG_LEVELS` env var, I highly recommend setting this at runtime to avoid confusion.

e.g.

```bash
ATOMA_LOG_LEVELS=trace docker compose --profile local up -d
```

will set the overall log level to `trace` 