### PR TITLE
fix: oauth missing password_salt

### DIFF
--- a/atoma-auth/src/auth.rs
+++ b/atoma-auth/src/auth.rs
@@ -410,9 +410,16 @@ impl Auth {
                 return Err(google::GoogleError::EmailNotFound)?;
             }
         };
+        // In case this user doesn't have an account yet, we will add the password salt
+        let password_salt = rand::thread_rng()
+            .sample_iter(&rand::distributions::Alphanumeric)
+            .take(30)
+            .map(char::from)
+            .collect::<String>();
         self.state_manager_sender
             .send(AtomaAtomaStateManagerEvent::OAuth {
                 email,
+                password_salt,
                 result_sender,
             })?;
         let user_id = result_receiver.await??;
@@ -1193,6 +1200,7 @@ active_address: "0x939cfcc7fcbc71ce983203bcb36fa498901932ab9293dfa2b271203e71603
             match event {
                 AtomaAtomaStateManagerEvent::OAuth {
                     email: event_email,
+                    password_salt: _,
                     result_sender,
                 } => {
                     assert_eq!(event_email, "email");

--- a/atoma-state/src/handlers.rs
+++ b/atoma-state/src/handlers.rs
@@ -1283,9 +1283,10 @@ pub async fn handle_state_manager_event(
         }
         AtomaAtomaStateManagerEvent::OAuth {
             email,
+            password_salt,
             result_sender,
         } => {
-            let user_id = state_manager.state.oauth(&email).await;
+            let user_id = state_manager.state.oauth(&email, &password_salt).await;
             result_sender
                 .send(user_id)
                 .map_err(|_| AtomaStateManagerError::ChannelSendError)?;

--- a/atoma-state/src/state_manager.rs
+++ b/atoma-state/src/state_manager.rs
@@ -3769,9 +3769,10 @@ impl AtomaState {
     ///    state_manager.oauth(email).await
     /// }
     /// ```
-    pub async fn oauth(&self, email: &str) -> Result<i64> {
-        let user = sqlx::query("INSERT INTO users (email) VALUES ($1) ON CONFLICT (email) DO UPDATE SET email = EXCLUDED.email RETURNING id")
+    pub async fn oauth(&self, email: &str, password_salt: &str) -> Result<i64> {
+        let user = sqlx::query("INSERT INTO users (email, password_salt) VALUES ($1, $2) ON CONFLICT (email) DO UPDATE SET email = EXCLUDED.email RETURNING id")
                 .bind(email)
+                .bind(password_salt)
                 .fetch_one(&self.db).await?;
 
         Ok(user.get("id"))

--- a/atoma-state/src/types.rs
+++ b/atoma-state/src/types.rs
@@ -796,6 +796,8 @@ pub enum AtomaAtomaStateManagerEvent {
     OAuth {
         /// The email of the user
         email: String,
+        /// Password salt
+        password_salt: String,
         /// The result sender to send back the user ID
         result_sender: oneshot::Sender<Result<i64>>,
     },


### PR DESCRIPTION
During oauth with try to insert into the `users` table, but the `password_salt` is `not null` so the query failed. In this PR we generate the `password_salt` for oauth users. When the user is already present the new password salt is ignored.