### PR TITLE
feat: drop name from users table

### DIFF
--- a/atoma-proxy-service/src/components/openapi.rs
+++ b/atoma-proxy-service/src/components/openapi.rs
@@ -13,10 +13,10 @@ use crate::{
         auth::{
             GenerateApiTokenOpenApi, GetAllApiTokensOpenApi, GetBalance, GetSuiAddress,
             GetUserProfile, GetZkSalt, LoginOpenApi, RegisterOpenApi, RevokeApiTokenOpenApi,
-            SetUserProfile, UpdateSuiAddress, UsdcPayment, GENERATE_API_TOKEN_PATH,
-            GET_ALL_API_TOKENS_PATH, GET_BALANCE_PATH, GET_SUI_ADDRESS_PATH, GET_USER_PROFILE_PATH,
-            GET_ZK_SALT_PATH, LOGIN_PATH, REGISTER_PATH, REVOKE_API_TOKEN_PATH,
-            SET_USER_PROFILE_PATH, UPDATE_SUI_ADDRESS_PATH, USDC_PAYMENT_PATH,
+            UpdateSuiAddress, UsdcPayment, GENERATE_API_TOKEN_PATH, GET_ALL_API_TOKENS_PATH,
+            GET_BALANCE_PATH, GET_SUI_ADDRESS_PATH, GET_USER_PROFILE_PATH, GET_ZK_SALT_PATH,
+            LOGIN_PATH, REGISTER_PATH, REVOKE_API_TOKEN_PATH, UPDATE_SUI_ADDRESS_PATH,
+            USDC_PAYMENT_PATH,
         },
         stacks::{
             GetCurrentStacksOpenApi, GetStacksByUserId, GET_ALL_STACKS_FOR_USER_PATH,
@@ -52,7 +52,6 @@ pub fn openapi_router() -> Router {
             (path = GET_ALL_STACKS_FOR_USER_PATH, api = GetStacksByUserId, tags = ["Stacks"]),
             (path = GET_BALANCE_PATH, api = GetBalance, tags = ["Auth"]),
             (path = GET_USER_PROFILE_PATH, api = GetUserProfile, tags = ["Auth"]),
-            (path = SET_USER_PROFILE_PATH, api = SetUserProfile, tags = ["Auth"]),
             (path = GET_ZK_SALT_PATH, api = GetZkSalt, tags = ["Auth"]),
             (path = TASKS_PATH, api = GetAllTasksOpenApi, tags = ["Tasks"]),
             (path = COMPUTE_UNITS_PROCESSED_PATH, api = GetComputeUnitsProcessed, tags = ["Stats"]),

--- a/atoma-proxy-service/src/handlers/auth.rs
+++ b/atoma-proxy-service/src/handlers/auth.rs
@@ -47,9 +47,6 @@ pub const GET_BALANCE_PATH: &str = "/balance";
 /// Get user profile endpoint
 pub const GET_USER_PROFILE_PATH: &str = "/user_profile";
 
-/// Set user profile endpoint
-pub const SET_USER_PROFILE_PATH: &str = "/set_user_profile";
-
 /// Set user's salt endpoint.
 pub const GET_ZK_SALT_PATH: &str = "/zk_salt";
 
@@ -84,7 +81,6 @@ pub fn auth_router() -> Router<ProxyServiceState> {
         .route(GET_SUI_ADDRESS_PATH, get(get_sui_address))
         .route(GET_BALANCE_PATH, get(get_balance))
         .route(GET_USER_PROFILE_PATH, get(get_user_profile))
-        .route(SET_USER_PROFILE_PATH, post(set_user_profile))
         .route(GET_ZK_SALT_PATH, get(get_zk_salt));
     #[cfg(feature = "google-oauth")]
     let router = router.route(GOOGLE_OAUTH_PATH, post(google_oauth));
@@ -661,70 +657,6 @@ pub async fn get_user_profile(
                 StatusCode::INTERNAL_SERVER_ERROR
             })?,
     ))
-}
-
-/// OpenAPI documentation for the set_user_profile endpoint.
-///
-/// This struct is used to generate OpenAPI documentation for the set_user_profile
-/// endpoint. It uses the `utoipa` crate's derive macro to automatically generate
-/// the OpenAPI specification from the code.
-#[derive(OpenApi)]
-#[openapi(paths(set_user_profile))]
-pub struct SetUserProfile;
-
-/// Retrieves the user profile for the user.
-///
-/// # Arguments
-///
-/// * `proxy_service_state` - The shared state containing the state manager
-/// * `headers` - The headers of the request
-///
-/// # Returns
-///
-/// * `Result<Json<Value>>` - A JSON response containing the user profile
-///
-/// # Errors
-///
-/// * If the user ID cannot be retrieved from the token, returns a 401 Unauthorized error
-/// * If the user profile cannot be retrieved, returns a 500 Internal Server Error
-#[utoipa::path(
-    get,
-    path = "",
-    security(
-        ("bearerAuth" = [])
-    ),
-    responses(
-        (status = OK, description = "Sets the user profile for the user"),
-        (status = UNAUTHORIZED, description = "Unauthorized request"),
-        (status = INTERNAL_SERVER_ERROR, description = "Failed to set user profile")
-    )
-)]
-#[instrument(level = "info", skip_all)]
-pub async fn set_user_profile(
-    State(proxy_service_state): State<ProxyServiceState>,
-    headers: HeaderMap,
-    Json(user_profile): Json<UserProfile>,
-) -> Result<Json<()>> {
-    let jwt = get_jwt_from_headers(&headers)?;
-
-    let user_id = proxy_service_state
-        .auth
-        .get_user_id_from_token(jwt)
-        .await
-        .map_err(|e| {
-            error!("Failed to get user ID from token: {:?}", e);
-            StatusCode::UNAUTHORIZED
-        })?;
-
-    proxy_service_state
-        .atoma_state
-        .set_user_profile(user_id, user_profile)
-        .await
-        .map_err(|e| {
-            error!("Failed to get user profile: {:?}", e);
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
-    Ok(Json(()))
 }
 
 /// OpenAPI documentation for the get_zk_salt endpoint.

--- a/atoma-state/src/migrations/20250325062641_drop-users-name.sql
+++ b/atoma-state/src/migrations/20250325062641_drop-users-name.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+DROP COLUMN name;

--- a/atoma-state/src/tests.rs
+++ b/atoma-state/src/tests.rs
@@ -303,14 +303,15 @@ async fn create_test_stack(
     num_compute_units: i64,
     user_id: i64,
 ) -> sqlx::Result<()> {
-    sqlx::query("INSERT INTO users (id, name, email, password_salt, password_hash) VALUES ($1, $2, $3, $4, $5)")
-        .bind(user_id)
-        .bind(format!("user_{user_id}")) // Create unique email
-        .bind(format!("test_user_{user_id}")) // Create unique email
-        .bind("test_password_salt") // Default password salt
-        .bind("test_password_hash") // Default password hash
-        .execute(pool)
-        .await?;
+    sqlx::query(
+        "INSERT INTO users (id, email, password_salt, password_hash) VALUES ($1, $2, $3, $4)",
+    )
+    .bind(user_id)
+    .bind(format!("user_{user_id}")) // Create unique email
+    .bind("test_password_salt") // Default password salt
+    .bind("test_password_hash") // Default password hash
+    .execute(pool)
+    .await?;
     sqlx::query(
         "INSERT INTO stacks (
                 stack_small_id,

--- a/atoma-state/src/types.rs
+++ b/atoma-state/src/types.rs
@@ -147,8 +147,6 @@ pub struct ComputedUnitsProcessedResponse {
 pub struct UserProfile {
     /// The user's email
     pub email: String,
-    /// The user's name
-    pub name: String,
 }
 
 /// Represents a latency response.


### PR DESCRIPTION
Drop the `name` from `users` table. Since there is no user settings that can be changed drop some the save user profile function/endpoint as well.