### PR TITLE
feat: add logic for acquire stack lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ source = "git+https://github.com/mystenlabs/anemo.git?rev=9c52c3c7946532163a7912
 dependencies = [
  "anemo",
  "bytes",
- "dashmap",
+ "dashmap 5.5.3",
  "futures",
  "governor",
  "nonzero_ext",
@@ -748,6 +748,7 @@ dependencies = [
  "blake2",
  "clap",
  "config",
+ "dashmap 6.1.0",
  "fastcrypto 0.1.8",
  "flume",
  "futures",
@@ -2037,6 +2038,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3124,7 +3139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68a7f542ee6b35af73b06abc0dad1c1bae89964e4e253bc4b587b91c9637867b"
 dependencies = [
  "cfg-if",
- "dashmap",
+ "dashmap 5.5.3",
  "futures",
  "futures-timer",
  "no-std-compat",
@@ -5457,7 +5472,7 @@ source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96b
 dependencies = [
  "async-trait",
  "axum",
- "dashmap",
+ "dashmap 5.5.3",
  "futures",
  "once_cell",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ blake3                = "1.6.1"
 chrono                = "=0.4.39"
 clap                  = "4.5.31"
 config                = "0.14.1"
+dashmap               = "6.1.0"
 fastcrypto            = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", package = "fastcrypto" }
 fastcrypto-zkp        = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", package = "fastcrypto-zkp" }
 fastrand              = "2.3.0"

--- a/atoma-proxy/Cargo.toml
+++ b/atoma-proxy/Cargo.toml
@@ -5,19 +5,20 @@ name              = "atoma-proxy"
 version.workspace = true
 
 [dependencies]
-anyhow.workspace = true
-async-trait.workspace = true
-atoma-auth.workspace = true
-atoma-p2p.workspace = true
-atoma-proxy-service.workspace = true
-atoma-state.workspace = true
-atoma-sui.workspace = true
-atoma-utils.workspace = true
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+atoma-auth = { workspace = true }
+atoma-p2p = { workspace = true }
+atoma-proxy-service = { workspace = true }
+atoma-state = { workspace = true }
+atoma-sui = { workspace = true }
+atoma-utils = { workspace = true }
 axum = { workspace = true, features = [ "json" ] }
 base64 = { workspace = true }
-blake2.workspace = true
-clap.workspace = true
-config.workspace = true
+blake2 = { workspace = true }
+clap = { workspace = true }
+config = { workspace = true }
+dashmap = { workspace = true }
 fastcrypto.workspace = true
 flume.workspace = true
 futures = { workspace = true }
@@ -35,19 +36,19 @@ opentelemetry_sdk = { workspace = true, features = [ "logs", "metrics", "rt-toki
 rand = { workspace = true }
 reqwest = { workspace = true, features = [ "json" ] }
 serde = { workspace = true, features = [ "derive" ] }
-serde_json.workspace = true
+serde_json = { workspace = true }
 serde_yaml = { workspace = true }
-sqlx.workspace = true
-sui-keys.workspace = true
-sui-sdk.workspace = true
+sqlx = { workspace = true }
+sui-keys = { workspace = true }
+sui-sdk = { workspace = true }
 thiserror = { workspace = true }
 tokenizers = { workspace = true }
 tokio = { workspace = true, features = [ "full" ] }
 tonic = { workspace = true, features = [ "prost", "tls", "tls-roots" ] }
 tower = { workspace = true }
 tower-http = { workspace = true, features = [ "cors" ] }
-tracing.workspace = true
-tracing-appender.workspace = true
+tracing = { workspace = true }
+tracing-appender = { workspace = true }
 tracing-loki = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true, features = [ "env-filter", "json", "time" ] }

--- a/atoma-proxy/src/server/handlers/chat_completions.rs
+++ b/atoma-proxy/src/server/handlers/chat_completions.rs
@@ -801,6 +801,7 @@ async fn handle_streaming_response(
 }
 
 /// Represents a chat completion request model following the OpenAI API format
+#[derive(Debug, Clone)]
 pub struct RequestModelChatCompletions {
     /// The identifier of the model to use for the completion
     /// (e.g., "gpt-3.5-turbo", "meta-llama/Llama-3.3-70B-Instruct", etc.)

--- a/atoma-proxy/src/server/handlers/embeddings.rs
+++ b/atoma-proxy/src/server/handlers/embeddings.rs
@@ -55,6 +55,7 @@ const INPUT: &str = "input";
 ///
 /// This struct encapsulates the necessary fields for processing an embeddings request
 /// following the OpenAI API format.
+#[derive(Debug, Clone)]
 pub struct RequestModelEmbeddings {
     /// The name of the model to use for generating embeddings (e.g., "text-embedding-ada-002")
     model: String,

--- a/atoma-proxy/src/server/handlers/image_generations.rs
+++ b/atoma-proxy/src/server/handlers/image_generations.rs
@@ -48,6 +48,7 @@ const SIZE: &str = "size";
 ///
 /// This struct encapsulates the required parameters for generating images through
 /// the API endpoint.
+#[derive(Debug, Clone)]
 pub struct RequestModelImageGenerations {
     /// The identifier of the AI model to use for image generation
     model: String,

--- a/atoma-proxy/src/server/handlers/request_model.rs
+++ b/atoma-proxy/src/server/handlers/request_model.rs
@@ -15,7 +15,7 @@ pub struct ComputeUnitsEstimate {
 /// A trait for parsing and handling AI model requests across different endpoints (chat, embeddings, images).
 /// This trait provides a common interface for processing various types of AI model requests
 /// and estimating their computational costs.
-pub trait RequestModel {
+pub trait RequestModel: Clone {
     /// Constructs a new request model instance by parsing the provided JSON request.
     ///
     /// # Arguments

--- a/atoma-proxy/src/server/http_server.rs
+++ b/atoma-proxy/src/server/http_server.rs
@@ -57,6 +57,8 @@ pub const HEALTH_PATH: &str = "/health";
 
 pub type UserId = i64;
 
+pub type TaskId = i64;
+
 /// Represents the shared state of the application.
 ///
 /// This struct holds various components and configurations that are shared
@@ -71,7 +73,11 @@ pub struct ProxyState {
     /// updates and notifications across different components.
     pub state_manager_sender: Sender<AtomaAtomaStateManagerEvent>,
 
-    pub users_buy_stack_lock_map: DashMap<UserId, bool>,
+    /// Map of user ids to their stack lock status.
+    ///
+    /// This map is used to prevent race conditions when multiple requests
+    /// try to acquire the same stack for a user.
+    pub users_buy_stack_lock_map: DashMap<(UserId, TaskId), bool>,
 
     /// `Sui` struct for handling Sui-related operations.
     ///

--- a/atoma-proxy/src/server/http_server.rs
+++ b/atoma-proxy/src/server/http_server.rs
@@ -7,6 +7,7 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
+use dashmap::DashMap;
 use flume::Sender;
 use reqwest::Method;
 use serde::Serialize;
@@ -54,6 +55,8 @@ use super::AtomaServiceConfig;
 /// This endpoint is used to check the health of the atoma proxy service.
 pub const HEALTH_PATH: &str = "/health";
 
+pub type UserId = i64;
+
 /// Represents the shared state of the application.
 ///
 /// This struct holds various components and configurations that are shared
@@ -67,6 +70,8 @@ pub struct ProxyState {
     /// state manager, allowing for efficient handling of application state
     /// updates and notifications across different components.
     pub state_manager_sender: Sender<AtomaAtomaStateManagerEvent>,
+
+    pub users_buy_stack_lock_map: DashMap<UserId, bool>,
 
     /// `Sui` struct for handling Sui-related operations.
     ///
@@ -243,6 +248,7 @@ pub async fn start_server(
 
     let proxy_state = ProxyState {
         state_manager_sender,
+        users_buy_stack_lock_map: DashMap::new(),
         sui,
         tokenizers: Arc::new(tokenizers),
         models: Arc::new(config.models),

--- a/atoma-proxy/src/server/middleware.rs
+++ b/atoma-proxy/src/server/middleware.rs
@@ -1196,6 +1196,7 @@ pub mod auth {
     /// # Arguments
     /// * `state` - Reference to the ProxyState containing application state
     /// * `user_id` - The ID of the user requesting the stack
+    /// * `task_small_id` - The small ID of the task that the user is requesting
     /// * `body_json` - The raw JSON request body as a serde_json Value
     /// * `endpoint` - The API endpoint being accessed
     ///
@@ -1221,6 +1222,7 @@ pub mod auth {
     async fn get_stack_if_locked(
         state: &ProxyState,
         user_id: i64,
+        task_small_id: i64,
         body_json: &Value,
         endpoint: &str,
     ) -> Result<SelectedNodeMetadata> {
@@ -1232,8 +1234,14 @@ pub mod auth {
                         endpoint: endpoint.to_string(),
                     }
                 })?;
-                get_stack_if_locked_with_request_model(state, user_id, request_model, endpoint)
-                    .await
+                get_stack_if_locked_with_request_model(
+                    state,
+                    user_id,
+                    task_small_id,
+                    request_model,
+                    endpoint,
+                )
+                .await
             }
             EMBEDDINGS_PATH => {
                 let request_model = RequestModelEmbeddings::new(body_json).map_err(|err| {
@@ -1242,8 +1250,14 @@ pub mod auth {
                         endpoint: endpoint.to_string(),
                     }
                 })?;
-                get_stack_if_locked_with_request_model(state, user_id, request_model, endpoint)
-                    .await
+                get_stack_if_locked_with_request_model(
+                    state,
+                    user_id,
+                    task_small_id,
+                    request_model,
+                    endpoint,
+                )
+                .await
             }
             IMAGE_GENERATIONS_PATH => {
                 let request_model =
@@ -1253,8 +1267,14 @@ pub mod auth {
                             endpoint: endpoint.to_string(),
                         }
                     })?;
-                get_stack_if_locked_with_request_model(state, user_id, request_model, endpoint)
-                    .await
+                get_stack_if_locked_with_request_model(
+                    state,
+                    user_id,
+                    task_small_id,
+                    request_model,
+                    endpoint,
+                )
+                .await
             }
             _ => {
                 return Err(AtomaProxyError::RequestError {
@@ -1274,6 +1294,7 @@ pub mod auth {
     /// # Arguments
     /// * `state` - Reference to the ProxyState containing application state
     /// * `user_id` - The ID of the user requesting the stack
+    /// * `task_small_id` - The small ID of the task that the user is requesting
     /// * `request_model` - Implementation of RequestModel trait containing request details
     /// * `endpoint` - The API endpoint being accessed
     ///
@@ -1295,13 +1316,14 @@ pub mod auth {
     async fn get_stack_if_locked_with_request_model(
         state: &ProxyState,
         user_id: i64,
+        task_small_id: i64,
         request_model: impl RequestModel + Send,
         endpoint: &str,
     ) -> Result<SelectedNodeMetadata> {
         let stack_is_locked = {
             state
                 .users_buy_stack_lock_map
-                .get(&user_id)
+                .get(&(user_id, task_small_id))
                 .is_some_and(|lock| *lock)
         };
         if stack_is_locked {
@@ -1453,12 +1475,14 @@ pub mod auth {
                 });
             }
         };
-        let Some(_lock_guard) =
-            acquire_stack_lock::LockGuard::try_lock(&state.users_buy_stack_lock_map, user_id)
-        else {
+        let Some(_lock_guard) = acquire_stack_lock::LockGuard::try_lock(
+            &state.users_buy_stack_lock_map,
+            (user_id, node.task_small_id),
+        ) else {
             // NOTE: Failed to acquire stack lock (meaning, we are in a race condition scenario)
             // so we try to get the stack from the state manager, and if it is not found, we return an error.
-            return get_stack_if_locked(state, user_id, body_json, endpoint).await;
+            return get_stack_if_locked(state, user_id, node.task_small_id, body_json, endpoint)
+                .await;
         };
         // NOTE: At this point, we have an acquired stack lock, so we can safely acquire a new stack.
         let NewStackResult {
@@ -2036,15 +2060,17 @@ pub mod acquire_stack_lock {
     use dashmap::DashMap;
     use tracing::{info, instrument};
 
+    use crate::server::http_server::{TaskId, UserId};
+
     /// A guard that locks a stack for a user id.
     ///
     /// This struct is used to lock a stack for a user id, so that no other concurrent requests can try to acquire a new stack,
     /// to avoid buying multiple redundant stacks, at the same time (that is in a window of 300ms, following Sui's Mysticeti fast finality estimation times).
     pub struct LockGuard<'a> {
-        /// The map of user id to lock status.
-        map: &'a DashMap<i64, bool>,
-        /// The user id to lock.
-        key: i64,
+        /// The map of user id and task id to lock status.
+        map: &'a DashMap<(UserId, TaskId), bool>,
+        /// The user id and task id to lock.
+        key: (UserId, TaskId),
         /// Whether the lock is held.
         locked: bool,
     }
@@ -2062,7 +2088,10 @@ pub mod acquire_stack_lock {
         /// # Returns
         ///
         /// Returns a new `LockGuard` if the stack is not locked, otherwise `None`.
-        pub fn try_lock(map: &'a DashMap<i64, bool>, key: i64) -> Option<Self> {
+        pub fn try_lock(
+            map: &'a DashMap<(UserId, TaskId), bool>,
+            key: (UserId, TaskId),
+        ) -> Option<Self> {
             match map.entry(key) {
                 dashmap::mapref::entry::Entry::Occupied(_) => None, // Already locked
                 dashmap::mapref::entry::Entry::Vacant(entry) => {
@@ -2082,12 +2111,15 @@ pub mod acquire_stack_lock {
         ///
         /// This method removes the lock from the map when the lock guard goes out of scope.
         /// It logs a message indicating that the lock has been released for the user id.
-        #[instrument(level = "info", skip_all, fields(user_id = %self.key))]
+        #[instrument(level = "info", skip_all, fields(user_id = %self.key.0, task_small_id = %self.key.1))]
         fn drop(&mut self) {
             if self.locked {
                 let previous_lock = self.map.remove(&self.key);
                 if previous_lock.is_some() {
-                    info!("Held lock has been released for user id: {}", self.key);
+                    info!(
+                        "Held lock has been released for user id: {} and task small id: {}",
+                        self.key.0, self.key.1
+                    );
                 }
             }
         }

--- a/atoma-proxy/src/server/middleware.rs
+++ b/atoma-proxy/src/server/middleware.rs
@@ -902,6 +902,7 @@ pub mod auth {
     async fn try_get_stack_for_user_id(
         state: &ProxyState,
         user_id: UserId,
+        task_small_id: i64,
         request_model: impl RequestModel + Send,
         endpoint: &str,
     ) -> Result<Option<SelectedNodeMetadata>> {
@@ -929,15 +930,14 @@ pub mod auth {
 
         state
             .state_manager_sender
-            .send(AtomaAtomaStateManagerEvent::GetStacksForModel {
-                model: model.to_string(),
+            .send(AtomaAtomaStateManagerEvent::GetStacksForTask {
+                task_small_id,
                 free_compute_units: max_total_compute_units as i64,
                 user_id,
-                is_confidential: false, // NOTE: This method is only used for non-confidential compute
                 result_sender,
             })
             .map_err(|err| AtomaProxyError::InternalError {
-                message: format!("Failed to send GetStacksForModel event: {err:?}"),
+                message: format!("Failed to send GetStacksForTask event: {err:?}"),
                 client_message: None,
                 endpoint: endpoint.to_string(),
             })?;
@@ -945,12 +945,12 @@ pub mod auth {
         let optional_stack = result_receiver
             .await
             .map_err(|err| AtomaProxyError::InternalError {
-                message: format!("Failed to receive GetStacksForModel result: {err:?}"),
+                message: format!("Failed to receive GetStacksForTask result: {err:?}"),
                 client_message: None,
                 endpoint: endpoint.to_string(),
             })?
             .map_err(|err| AtomaProxyError::InternalError {
-                message: format!("Failed to get GetStacksForModel result: {err:?}"),
+                message: format!("Failed to get GetStacksForTask result: {err:?}"),
                 client_message: None,
                 endpoint: endpoint.to_string(),
             })?;
@@ -1334,9 +1334,14 @@ pub mod auth {
             // finality times). We will try again, for a fixed number of times. If the stack is still not created,
             // we return an error.
             for _ in 0..MAX_STACK_WAIT_ATTEMPTS {
-                let stack_metadata =
-                    try_get_stack_for_user_id(state, user_id, request_model.clone(), endpoint)
-                        .await?;
+                let stack_metadata = try_get_stack_for_user_id(
+                    state,
+                    user_id,
+                    task_small_id,
+                    request_model.clone(),
+                    endpoint,
+                )
+                .await?;
                 if let Some(stack_metadata) = stack_metadata {
                     return Ok(stack_metadata);
                 }

--- a/atoma-proxy/src/server/middleware.rs
+++ b/atoma-proxy/src/server/middleware.rs
@@ -1474,6 +1474,9 @@ pub mod auth {
                 node,
             )
             .await?;
+            // NOTE: The `acquire_new_stack` method will emit a stack creation event, and it will stored it
+            // in the AtomaStateManager's internal state, for this reason it is safe to remove the lock here,
+            // as any new request querying the state manager after this lock removal will see the new stack.
             state.users_buy_stack_lock_map.remove(&user_id);
             new_stack_result
         };

--- a/atoma-state/src/handlers.rs
+++ b/atoma-state/src/handlers.rs
@@ -1052,6 +1052,26 @@ pub async fn handle_state_manager_event(
                 .send(stack)
                 .map_err(|_| AtomaStateManagerError::ChannelSendError)?;
         }
+        AtomaAtomaStateManagerEvent::GetStacksForTask {
+            task_small_id,
+            free_compute_units,
+            user_id,
+            result_sender,
+        } => {
+            trace!(
+                target = "atoma-state-handlers",
+                event = "handle-state-manager-event",
+                "Getting stacks for task with id: {}",
+                task_small_id
+            );
+            let stack = state_manager
+                .state
+                .get_stacks_for_task(task_small_id, free_compute_units, user_id)
+                .await;
+            result_sender
+                .send(stack)
+                .map_err(|_| AtomaStateManagerError::ChannelSendError)?;
+        }
         AtomaAtomaStateManagerEvent::GetTasksForModel {
             model,
             result_sender,

--- a/atoma-state/src/state_manager.rs
+++ b/atoma-state/src/state_manager.rs
@@ -389,6 +389,54 @@ impl AtomaState {
         Ok(stack)
     }
 
+    /// Get a stack by its unique identifier.
+    ///
+    /// This method fetches a stack from the database based on the provided `task_small_id`.
+    ///
+    /// # Arguments
+    ///
+    /// * `task_small_id` - The unique identifier for the task to be fetched.
+    /// * `free_units` - The number of free units available.
+    /// * `user_id` - The user id of the stacks to filter by.
+    ///
+    /// # Returns
+    ///
+    /// - `Result<Option<Stack>>`: A result containing either:  
+    ///  - `Ok(Some(Stack))`: The stack with the specified `task_small_id`.
+    ///  - `Err(AtomaStateManagerError)`: An error if the database query fails or if there's an issue parsing the results.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the database query fails.
+    #[instrument(level = "trace", skip_all, fields(%task_small_id, %free_units, %user_id))]
+    pub async fn get_stacks_for_task(
+        &self,
+        task_small_id: i64,
+        free_units: i64,
+        user_id: i64,
+    ) -> Result<Option<Stack>> {
+        let stack = sqlx::query(
+            "
+        SELECT * FROM stacks 
+            WHERE task_small_id = $1 
+            AND num_compute_units - already_computed_units >= $2 
+            AND user_id = $3 
+            AND is_claimed = false 
+            AND is_locked = false 
+            AND in_settle_period = false
+            LIMIT 1
+            ",
+        )
+        .bind(task_small_id)
+        .bind(free_units)
+        .bind(user_id)
+        .fetch_optional(&self.db)
+        .await?
+        .map(|stack| Stack::from_row(&stack).map_err(AtomaStateManagerError::from))
+        .transpose()?;
+        Ok(stack)
+    }
+
     /// Get tasks for model.
     ///
     /// This method fetches all tasks from the database that are associated with

--- a/atoma-state/src/types.rs
+++ b/atoma-state/src/types.rs
@@ -624,6 +624,16 @@ pub enum AtomaAtomaStateManagerEvent {
         /// Returns Ok(Vec<Stack>) with matching stacks or an error if the query fails
         result_sender: oneshot::Sender<Result<Option<Stack>>>,
     },
+    GetStacksForTask {
+        /// Unique small integer identifier for the task
+        task_small_id: i64,
+        /// The minimum number of available compute units required
+        free_compute_units: i64,
+        /// The user id of the stacks to filter by
+        user_id: i64,
+        /// Channel to send back the list of matching stacks
+        result_sender: oneshot::Sender<Result<Option<Stack>>>,
+    },
     /// Verifies if a stack is valid for confidential compute request
     VerifyStackForConfidentialComputeRequest {
         /// Unique small integer identifier for the stack


### PR DESCRIPTION
@Cifko we need to review this one very carefully, and test it throughly.

I have introduced a new struct `LockGuard` to ensure that the any acquire stack lock encapsules the entire logic of acquiring a new stack (and there are no possible race conditions between logical branches, otherwise).

This `LockGuard` also implements the `Drop` trait making sure that resources are cleanup appropriately. We should do the same for the `DashMap` use in the `atoma-node` for counting concurrent requests.

```rs
    /// A guard that locks a stack for a user id.
    ///
    /// This struct is used to lock a stack for a user id, so that no other concurrent requests can try to acquire a new stack,
    /// to avoid buying multiple redundant stacks, at the same time (that is in a window of 300ms, following Sui's Mysticeti fast finality estimation times).
    pub struct LockGuard<'a> {
        /// The map of user id to lock status.
        map: &'a DashMap<i64, bool>,
        /// The user id to lock.
        key: i64,
        /// Whether the lock is held.
        locked: bool,
    }
    impl<'a> LockGuard<'a> {
        /// Tries to lock a stack for a user id.
        ///
        /// This method checks if the user id is already locked in the map. If it is, it returns `None`,
        /// indicating that the stack is already locked. Otherwise, it locks the stack and returns a new `LockGuard`.
        ///
        /// # Arguments
        ///
        /// * `map` - The map of user id to lock status.
        /// * `key` - The user id to lock.
        ///
        /// # Returns
        ///
        /// Returns a new `LockGuard` if the stack is not locked, otherwise `None`.
        pub fn try_lock(map: &'a DashMap<i64, bool>, key: i64) -> Option<Self> {
            match map.entry(key) {
                dashmap::mapref::entry::Entry::Occupied(_) => None, // Already locked
                dashmap::mapref::entry::Entry::Vacant(entry) => {
                    entry.insert(true);
                    Some(Self {
                        map,
                        key,
                        locked: true,
                    })
                }
            }
        }
    }

    impl Drop for LockGuard<'_> {
        /// Drops the lock guard and releases the lock.
        ///
        /// This method removes the lock from the map when the lock guard goes out of scope.
        /// It logs a message indicating that the lock has been released for the user id.
        #[instrument(level = "info", skip_all, fields(user_id = %self.key))]
        fn drop(&mut self) {
            if self.locked {
                let previous_lock = self.map.remove(&self.key);
                if previous_lock.is_some() {
                    info!("Held lock has been released for user id: {}", self.key);
                }
            }
        }
    }
```