### PR TITLE
fix: remove auth from models handler

### DIFF
--- a/atoma-proxy/src/server/handlers/models.rs
+++ b/atoma-proxy/src/server/handlers/models.rs
@@ -1,9 +1,7 @@
-use axum::http::HeaderMap;
 use axum::{extract::State, Json};
 use serde::{Deserialize, Serialize};
 use utoipa::{OpenApi, ToSchema};
 
-use crate::server::check_auth;
 use crate::server::error::AtomaProxyError;
 use crate::server::http_server::ProxyState;
 
@@ -40,7 +38,6 @@ pub struct ModelsOpenApi;
 )]
 pub async fn models_list(
     State(state): State<ProxyState>,
-    headers: HeaderMap,
 ) -> std::result::Result<Json<ModelList>, AtomaProxyError> {
     let models = state
         .models

--- a/atoma-proxy/src/server/handlers/models.rs
+++ b/atoma-proxy/src/server/handlers/models.rs
@@ -42,15 +42,6 @@ pub async fn models_list(
     State(state): State<ProxyState>,
     headers: HeaderMap,
 ) -> std::result::Result<Json<ModelList>, AtomaProxyError> {
-    if check_auth(&state.state_manager_sender, &headers, MODELS_PATH)
-        .await
-        .is_err()
-    {
-        return Err(AtomaProxyError::AuthError {
-            auth_error: "Unauthorized, client did not provide a valid API key".to_string(),
-            endpoint: MODELS_PATH.to_string(),
-        });
-    }
     let models = state
         .models
         .iter()


### PR DESCRIPTION
The auth was there twice. It should be only in the middleware