### PR TITLE
feat: handle too early requests

### DIFF
--- a/atoma-proxy/src/server/error.rs
+++ b/atoma-proxy/src/server/error.rs
@@ -109,6 +109,15 @@ pub enum AtomaProxyError {
         /// The endpoint that the error occurred on
         endpoint: String,
     },
+
+    /// Error returned when a specific stack is unavailable
+    #[error("Stack unavailable: {message}")]
+    UnavailableStack {
+        /// Description of the stack unavailable
+        message: String,
+        /// The endpoint that the error occurred on
+        endpoint: String,
+    },
 }
 
 impl AtomaProxyError {
@@ -137,6 +146,7 @@ impl AtomaProxyError {
             Self::ServiceUnavailable { .. } => "SERVICE_UNAVAILABLE",
             Self::BalanceError { .. } => "BALANCE_ERROR",
             Self::Locked { .. } => "LOCKED",
+            Self::UnavailableStack { .. } => "UNAVAILABLE_STACK",
         }
     }
 
@@ -167,6 +177,7 @@ impl AtomaProxyError {
             Self::ServiceUnavailable { .. } => "Service unavailable".to_string(),
             Self::BalanceError { .. } => "Insufficient balance".to_string(),
             Self::Locked { .. } => "Locked".to_string(),
+            Self::UnavailableStack { .. } => "Stack unavailable".to_string(),
         }
     }
 
@@ -190,6 +201,7 @@ impl AtomaProxyError {
             Self::ServiceUnavailable { .. } => StatusCode::SERVICE_UNAVAILABLE,
             Self::BalanceError { .. } => StatusCode::PAYMENT_REQUIRED,
             Self::Locked { .. } => StatusCode::LOCKED,
+            Self::UnavailableStack { .. } => StatusCode::TOO_EARLY,
         }
     }
 
@@ -210,7 +222,8 @@ impl AtomaProxyError {
             | Self::NotImplemented { endpoint, .. }
             | Self::ServiceUnavailable { endpoint, .. }
             | Self::BalanceError { endpoint, .. }
-            | Self::Locked { endpoint, .. } => endpoint.clone(),
+            | Self::Locked { endpoint, .. }
+            | Self::UnavailableStack { endpoint, .. } => endpoint.clone(),
         }
     }
 
@@ -239,6 +252,7 @@ impl AtomaProxyError {
             Self::ServiceUnavailable { message, .. } => format!("Service unavailable: {message}"),
             Self::BalanceError { message, .. } => format!("Insufficient balance: {message}"),
             Self::Locked { message, .. } => format!("Locked: {message}"),
+            Self::UnavailableStack { message, .. } => format!("Stack unavailable: {message}"),
         }
     }
 }

--- a/atoma-proxy/src/server/handlers/chat_completions.rs
+++ b/atoma-proxy/src/server/handlers/chat_completions.rs
@@ -177,7 +177,7 @@ pub async fn chat_completions_create(
                 update_state_manager(
                     &state.state_manager_sender,
                     metadata.selected_stack_small_id,
-                    metadata.num_compute_units as i64,
+                    metadata.max_total_num_compute_units as i64,
                     0,
                     &metadata.endpoint,
                 )?;
@@ -262,7 +262,7 @@ async fn handle_chat_completions_request(
             headers,
             &payload,
             metadata.num_input_tokens.map(|v| v as i64),
-            metadata.num_compute_units as i64,
+            metadata.max_total_num_compute_units as i64,
             metadata.selected_stack_small_id,
             metadata.endpoint.clone(),
             metadata.model_name.clone(),
@@ -275,7 +275,7 @@ async fn handle_chat_completions_request(
             metadata.node_id,
             headers,
             &payload,
-            metadata.num_compute_units as i64,
+            metadata.max_total_num_compute_units as i64,
             metadata.selected_stack_small_id,
             metadata.endpoint.clone(),
             metadata.model_name.clone(),
@@ -428,7 +428,7 @@ pub async fn confidential_chat_completions_create(
                 update_state_manager(
                     &state.state_manager_sender,
                     metadata.selected_stack_small_id,
-                    metadata.num_compute_units as i64,
+                    metadata.max_total_num_compute_units as i64,
                     0,
                     &metadata.endpoint,
                 )?;

--- a/atoma-proxy/src/server/handlers/embeddings.rs
+++ b/atoma-proxy/src/server/handlers/embeddings.rs
@@ -173,7 +173,7 @@ pub async fn embeddings_create(
         let RequestMetadataExtension {
             node_address,
             node_id,
-            num_compute_units: num_input_compute_units,
+            max_total_num_compute_units: num_input_compute_units,
             ..
         } = metadata;
         match handle_embeddings_response(
@@ -269,7 +269,7 @@ pub async fn confidential_embeddings_create(
         let RequestMetadataExtension {
             node_address,
             node_id,
-            num_compute_units: num_input_compute_units,
+            max_total_num_compute_units: num_input_compute_units,
             ..
         } = metadata;
         match handle_embeddings_response(

--- a/atoma-proxy/src/server/handlers/image_generations.rs
+++ b/atoma-proxy/src/server/handlers/image_generations.rs
@@ -172,7 +172,7 @@ pub async fn image_generations_create(
             metadata.node_id,
             headers,
             payload,
-            metadata.num_compute_units as i64,
+            metadata.max_total_num_compute_units as i64,
             metadata.endpoint.clone(),
             metadata.model_name.clone(),
             metadata.selected_stack_small_id,
@@ -195,7 +195,7 @@ pub async fn image_generations_create(
                 update_state_manager(
                     &state.state_manager_sender,
                     metadata.selected_stack_small_id,
-                    metadata.num_compute_units as i64,
+                    metadata.max_total_num_compute_units as i64,
                     0,
                     &metadata.endpoint,
                 )?;
@@ -265,7 +265,7 @@ pub async fn confidential_image_generations_create(
             metadata.node_id,
             headers,
             payload,
-            metadata.num_compute_units as i64,
+            metadata.max_total_num_compute_units as i64,
             metadata.endpoint.clone(),
             metadata.model_name.clone(),
             metadata.selected_stack_small_id,
@@ -289,7 +289,7 @@ pub async fn confidential_image_generations_create(
                 update_state_manager(
                     &state.state_manager_sender,
                     metadata.selected_stack_small_id,
-                    metadata.num_compute_units as i64,
+                    metadata.max_total_num_compute_units as i64,
                     0,
                     &metadata.endpoint,
                 )?;

--- a/atoma-proxy/src/server/handlers/metrics.rs
+++ b/atoma-proxy/src/server/handlers/metrics.rs
@@ -325,3 +325,33 @@ pub static TOTAL_FAILED_TEXT_EMBEDDING_REQUESTS: Lazy<Counter<u64>> = Lazy::new(
         .with_unit("requests")
         .build()
 });
+
+/// Counter metric that tracks the total number of stack unavailable errors.
+///
+/// # Metric Details
+/// - Name: `atoma_stack_unavailable_counter`
+/// - Type: Counter
+/// - Labels: `model`
+/// - Unit: requests (count)
+pub static STACK_UNAVAILABLE_COUNTER: Lazy<Counter<u64>> = Lazy::new(|| {
+    GLOBAL_METER
+        .u64_counter("atoma_stack_unavailable_counter")
+        .with_description("Total number of stack unavailable errors")
+        .with_unit("requests")
+        .build()
+});
+
+/// Counter metric that tracks the total number of stack locked errors.
+///
+/// # Metric Details
+/// - Name: `atoma_stack_locked_counter`
+/// - Type: Counter
+/// - Labels: `model`
+/// - Unit: requests (count)
+pub static STACK_LOCKED_COUNTER: Lazy<Counter<u64>> = Lazy::new(|| {
+    GLOBAL_METER
+        .u64_counter("atoma_stack_locked_counter")
+        .with_description("Total number of stack locked errors")
+        .with_unit("requests")
+        .build()
+});

--- a/atoma-proxy/src/server/middleware.rs
+++ b/atoma-proxy/src/server/middleware.rs
@@ -1656,7 +1656,7 @@ pub mod auth {
             }
         }
         Err(AtomaProxyError::RequestError {
-            message: format!("User {user_id} has already bought a stack"),
+            message: "Many concurrent requests, a stack is being bought, but its internal state is not yet updated. Please retry.".to_string(),
             endpoint: endpoint.to_string(),
         })
     }

--- a/atoma-proxy/src/server/middleware.rs
+++ b/atoma-proxy/src/server/middleware.rs
@@ -1860,7 +1860,7 @@ pub mod auth {
             lock_guard,
             endpoint.to_string(),
             max_total_num_compute_units,
-            Arc::clone(state.sui),
+            Arc::clone(&state.sui),
             node,
         )
         .await
@@ -2027,6 +2027,7 @@ pub mod utils {
             num_input_tokens: Some(num_input_tokens),
             num_compute_units: total_compute_units,
             selected_stack_small_id,
+            user_id,
             endpoint: endpoint.to_string(),
             model_name: request_model.to_string(),
         });


### PR DESCRIPTION
Due to overestimation of compute units, a node might not have enough available compute units for a stack and send a lock message to the proxy, in scenarios of multiple concurrent requests. This is not ideal, as the stack might not be locked (and actually far from it), so there is not reason for the proxy to locked it in its internal state.

Instead, we introduce a new status code `TOO_EARLY`, meaning that this request needs either to be retried at a moment's later (confidential endpoint) or the proxy just acquires a new stack for that user's and model/task, so that it then can handle such large volumes of concurrent requests at the same time.

Confidential endpoints requires a full retrial (no stack to be bought by the proxy), as the request was encrypted with a specific stack assigned node's public encryption key. So instead, the logic should be on the Atoma's SDKs to retry for a few times.