### PR TITLE
feat: add OpenRouter models support and configuration

### DIFF
--- a/atoma-proxy/docs/openapi.yml
+++ b/atoma-proxy/docs/openapi.yml
@@ -342,6 +342,24 @@ paths:
           description: Failed to retrieve list of available models
       security:
       - bearerAuth: []
+  /v1/open_router/models:
+    get:
+      tags:
+      - Models
+      summary: OpenRouter models listing endpoint
+      description: |-
+        This endpoint returns a list of available models from the OpenRouter
+        models file. The file is expected to be in JSON format and contains
+        information about the models, including their IDs and other metadata.
+      operationId: open_router_models_list
+      responses:
+        '200':
+          description: List of available models
+          content:
+            application/json:
+              schema: {}
+        '500':
+          description: Failed to retrieve list of available models
   /v1/nodes:
     post:
       tags:

--- a/atoma-proxy/src/server/components/openapi.rs
+++ b/atoma-proxy/src/server/components/openapi.rs
@@ -19,7 +19,7 @@ use crate::server::handlers::{
     embeddings::EMBEDDINGS_PATH,
     image_generations::ImageGenerationsOpenApi,
     image_generations::IMAGE_GENERATIONS_PATH,
-    models::{ModelsOpenApi, MODELS_PATH},
+    models::{ModelsOpenApi, OpenRouterModelsListApi, MODELS_PATH, OPEN_ROUTER_MODELS_PATH},
     nodes::NodesOpenApi,
 };
 use crate::server::handlers::{
@@ -42,6 +42,7 @@ pub fn openapi_routes() -> Router {
             (path = HEALTH_PATH, api = HealthOpenApi, tags = ["Health"]),
             (path = IMAGE_GENERATIONS_PATH, api = ImageGenerationsOpenApi, tags = ["Images"]),
             (path = MODELS_PATH, api = ModelsOpenApi, tags = ["Models"]),
+            (path = OPEN_ROUTER_MODELS_PATH, api = OpenRouterModelsListApi, tags = ["Models"]),
             (path = NODES_PATH, api = NodesOpenApi, tags = ["Nodes"]),
         ),
         tags(

--- a/atoma-proxy/src/server/config.rs
+++ b/atoma-proxy/src/server/config.rs
@@ -39,6 +39,9 @@ pub struct AtomaServiceConfig {
     /// This field contains the Hugging Face API token that is used to authenticate
     /// requests to the Hugging Face API.
     pub hf_token: String,
+
+    /// Path to open router json.
+    pub open_router_models_file: String,
 }
 
 impl AtomaServiceConfig {

--- a/atoma-proxy/src/server/handlers/models.rs
+++ b/atoma-proxy/src/server/handlers/models.rs
@@ -84,6 +84,15 @@ pub struct Model {
     pub owned_by: String,
 }
 
+/// OpenAPI documentation for the open router models listing endpoint.
+///
+/// This struct is used to generate OpenAPI documentation for the models listing
+/// endpoint. It uses the `utoipa` crate's derive macro to automatically generate
+/// the OpenAPI specification from the code.
+#[derive(OpenApi)]
+#[openapi(paths(open_router_models_list))]
+pub struct OpenRouterModelsListApi;
+
 /// OpenRouter models listing endpoint
 ///
 /// This endpoint returns a list of available models from the OpenRouter
@@ -91,10 +100,7 @@ pub struct Model {
 /// information about the models, including their IDs and other metadata.
 #[utoipa::path(
     get,
-    path = "/v1/open_router/models",
-    security(
-        ("bearerAuth" = [])
-    ),
+    path = "",
     responses(
         (status = OK, description = "List of available models", body = Value),
         (status = INTERNAL_SERVER_ERROR, description = "Failed to retrieve list of available models")

--- a/atoma-proxy/src/server/handlers/models.rs
+++ b/atoma-proxy/src/server/handlers/models.rs
@@ -89,14 +89,14 @@ pub async fn open_router_models_list(
     let file_content = fs::read_to_string(state.open_router_models_file)
         .await
         .map_err(|err| AtomaProxyError::InternalError {
-            message: format!("Failed to read OpenRouter models file: {}", err),
+            message: format!("Failed to read OpenRouter models file: {err}"),
             client_message: None,
             endpoint: OPEN_ROUTER_MODELS_PATH.to_string(),
         })?;
 
     let json_data: Value =
         serde_json::from_str(&file_content).map_err(|err| AtomaProxyError::InternalError {
-            message: format!("Failed to parse OpenRouter models file: {}", err),
+            message: format!("Failed to parse OpenRouter models file: {err}"),
             client_message: None,
             endpoint: OPEN_ROUTER_MODELS_PATH.to_string(),
         })?;

--- a/atoma-proxy/src/server/handlers/models.rs
+++ b/atoma-proxy/src/server/handlers/models.rs
@@ -1,6 +1,7 @@
 use axum::{extract::State, Json};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use tracing::instrument;
 use utoipa::{OpenApi, ToSchema};
 
 use crate::server::error::AtomaProxyError;
@@ -83,6 +84,23 @@ pub struct Model {
     pub owned_by: String,
 }
 
+/// OpenRouter models listing endpoint
+///
+/// This endpoint returns a list of available models from the OpenRouter
+/// models file. The file is expected to be in JSON format and contains
+/// information about the models, including their IDs and other metadata.
+#[utoipa::path(
+    get,
+    path = "/v1/open_router/models",
+    security(
+        ("bearerAuth" = [])
+    ),
+    responses(
+        (status = OK, description = "List of available models", body = Value),
+        (status = INTERNAL_SERVER_ERROR, description = "Failed to retrieve list of available models")
+    )
+)]
+#[instrument(level = "trace", skip_all)]
 pub async fn open_router_models_list(
     State(state): State<ProxyState>,
 ) -> std::result::Result<Json<Value>, AtomaProxyError> {

--- a/atoma-proxy/src/server/http_server.rs
+++ b/atoma-proxy/src/server/http_server.rs
@@ -45,6 +45,7 @@ use super::handlers::embeddings::{confidential_embeddings_create, CONFIDENTIAL_E
 use super::handlers::image_generations::{
     confidential_image_generations_create, CONFIDENTIAL_IMAGE_GENERATIONS_PATH,
 };
+use super::handlers::models::{open_router_models_list, OPEN_ROUTER_MODELS_PATH};
 use super::handlers::nodes::{
     nodes_create, nodes_create_lock, NODES_CREATE_LOCK_PATH, NODES_CREATE_PATH,
 };
@@ -128,6 +129,9 @@ pub struct ProxyState {
     /// application to dynamically select and switch between different
     /// models as needed.
     pub models: Arc<Vec<String>>,
+
+    /// Open router models file.
+    pub open_router_models_file: String,
 }
 
 #[derive(OpenApi)]
@@ -223,7 +227,9 @@ pub fn create_router(state: &ProxyState) -> Router {
         .route(NODES_CREATE_PATH, post(nodes_create))
         .route(NODES_CREATE_LOCK_PATH, post(nodes_create_lock));
 
-    let public_routes = Router::new().route(HEALTH_PATH, get(health));
+    let public_routes = Router::new()
+        .route(HEALTH_PATH, get(health))
+        .route(OPEN_ROUTER_MODELS_PATH, get(open_router_models_list));
 
     Router::new()
         .merge(
@@ -287,6 +293,7 @@ pub async fn start_server(
         sui,
         tokenizers: Arc::new(tokenizers),
         models: Arc::new(config.models),
+        open_router_models_file: config.open_router_models_file,
     };
     let router = create_router(&proxy_state);
     let server =

--- a/config.example.toml
+++ b/config.example.toml
@@ -40,6 +40,7 @@ models = [
 password = "password" # Authentication password for the service API
 revisions = [ "main", "main" ] # Model revision/version tags (must match models array length)
 service_bind_address = "0.0.0.0:8080" # HTTP service binding address and port (must match docker-compose.yml)
+open_router_json = "/app/open_router.json" # Path to the Open Router JSON file for model configuration
 
 [atoma_proxy_service]
 grafana_api_token     = ""             # Grafana API token (read-only permissions required)

--- a/config.example.toml
+++ b/config.example.toml
@@ -37,10 +37,10 @@ modalities = [
 models = [
     "Infermatic/Llama-3.3-70B-Instruct-FP8-Dynamic",
 ] # List of supported LLM models by the current proxy
+open_router_json = "/app/open_router.json" # Path to the Open Router JSON file for model configuration
 password = "password" # Authentication password for the service API
 revisions = [ "main", "main" ] # Model revision/version tags (must match models array length)
 service_bind_address = "0.0.0.0:8080" # HTTP service binding address and port (must match docker-compose.yml)
-open_router_json = "/app/open_router.json" # Path to the Open Router JSON file for model configuration
 
 [atoma_proxy_service]
 grafana_api_token     = ""             # Grafana API token (read-only permissions required)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,7 @@ x-atoma-proxy-base: &atoma-proxy-base
     dockerfile: Dockerfile
   volumes:
     - ${CONFIG_PATH:-./config.toml}:/app/config.toml
+    - ./open_router.json:/app/open_router.json
     - ./logs:/app/logs
     - sui-config-volume:/root/.sui/sui_config
     - ${SUI_CONFIG_PATH:-~/.sui/sui_config}:/tmp/.sui/sui_config

--- a/open_router.example.json
+++ b/open_router.example.json
@@ -1,0 +1,19 @@
+{
+  "data": [
+    {
+      "id": "anthropic/claude-2.0",
+      "name": "Anthropic: Claude v2.0",
+      "created": 1690502400,
+      "description": "Anthropic's flagship model...",
+      "context_length": 100000,
+      "max_completion_tokens": 4096,
+      "quantization": "fp8",
+      "pricing": {
+        "prompt": "0.000008",
+        "completion": "0.000024",
+        "image": "0",
+        "request": "0"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Add new open router models endpoint.
It just copy the content of the json file. So we need to add proper file. The `open_router.json` is mapped to docker to provide the content.