### PR TITLE
chore: bump sui,utoipa,axum version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
  "rcgen",
  "ring",
  "rustls",
- "rustls-webpki 0.103.0",
+ "rustls-webpki 0.103.1",
  "serde",
  "serde_json",
  "socket2",
@@ -571,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cf008e5e1a9e9e22a7d3c9a4992e21a350290069e36d8fb72304ed17e8f2d2"
+checksum = "59a194f9d963d8099596278594b3107448656ba73831c9d8c783e613ce86da64"
 dependencies = [
  "brotli",
  "flate2",
@@ -707,10 +707,10 @@ dependencies = [
  "rsa 0.9.8",
  "serde",
  "serde_json",
- "shared-crypto 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "sui-keys 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "sui-sdk 1.46.2",
- "sui-sdk-types 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shared-crypto",
+ "sui-keys",
+ "sui-sdk",
+ "sui-sdk-types 0.0.2",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -719,7 +719,7 @@ dependencies = [
 [[package]]
 name = "atoma-p2p"
 version = "0.1.0"
-source = "git+https://github.com/atoma-network/atoma-node.git?branch=main#9a2ae09679971351a010ae2f9688eeead0c5a540"
+source = "git+https://github.com/atoma-network/atoma-node.git?branch=openrouter-integration#2cfb4feb82e57bc558c28609c5e914f310f47200"
 dependencies = [
  "blake3",
  "bytes",
@@ -737,8 +737,8 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sui-keys 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "sui-sdk 1.45.2",
+ "sui-keys",
+ "sui-sdk",
  "sysinfo",
  "thiserror 2.0.12",
  "tokio",
@@ -759,7 +759,7 @@ dependencies = [
  "atoma-state",
  "atoma-sui",
  "atoma-utils",
- "axum",
+ "axum 0.8.3",
  "base64 0.22.1",
  "blake2",
  "clap",
@@ -779,8 +779,8 @@ dependencies = [
  "serde_json",
  "serde_yaml 0.9.34+deprecated",
  "sqlx",
- "sui-keys 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "sui-sdk 1.46.2",
+ "sui-keys",
+ "sui-sdk",
  "thiserror 2.0.12",
  "tokenizers",
  "tokio",
@@ -806,7 +806,7 @@ dependencies = [
  "atoma-auth",
  "atoma-state",
  "atoma-sui",
- "axum",
+ "axum 0.8.3",
  "base64 0.22.1",
  "chrono",
  "config",
@@ -815,7 +815,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml 0.9.34+deprecated",
- "sui-sdk 1.46.2",
+ "sui-sdk",
  "thiserror 2.0.12",
  "tokio",
  "tower-http 0.6.2",
@@ -862,7 +862,7 @@ dependencies = [
 [[package]]
 name = "atoma-sui"
 version = "0.1.0"
-source = "git+https://github.com/atoma-network/atoma-node.git?branch=main#9a2ae09679971351a010ae2f9688eeead0c5a540"
+source = "git+https://github.com/atoma-network/atoma-node.git?branch=openrouter-integration#2cfb4feb82e57bc558c28609c5e914f310f47200"
 dependencies = [
  "anyhow",
  "config",
@@ -871,7 +871,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
- "sui-sdk 1.45.2",
+ "sui-sdk",
  "thiserror 2.0.12",
  "tokio",
  "toml 0.8.20",
@@ -881,11 +881,11 @@ dependencies = [
 [[package]]
 name = "atoma-utils"
 version = "0.1.0"
-source = "git+https://github.com/atoma-network/atoma-node.git?branch=main#9a2ae09679971351a010ae2f9688eeead0c5a540"
+source = "git+https://github.com/atoma-network/atoma-node.git?branch=openrouter-integration#2cfb4feb82e57bc558c28609c5e914f310f47200"
 dependencies = [
  "aes-gcm",
  "anyhow",
- "axum",
+ "axum 0.7.9",
  "blake2",
  "fastcrypto 0.1.9",
  "flate2",
@@ -893,7 +893,7 @@ dependencies = [
  "rand 0.8.5",
  "serde_json",
  "sha2 0.10.8",
- "sui-sdk 1.45.2",
+ "sui-sdk",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -936,7 +936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.4.5",
  "axum-macros",
  "base64 0.22.1",
  "bytes",
@@ -968,6 +968,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de45108900e1f9b9242f7f2e254aa3e2c029c921c258fe9e6b4217eeebd54288"
+dependencies = [
+ "axum-core 0.5.2",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http 1.3.1",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "axum-core"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -976,6 +1010,26 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
+ "http 1.3.1",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
+dependencies = [
+ "bytes",
+ "futures-core",
  "http 1.3.1",
  "http-body",
  "http-body-util",
@@ -1438,9 +1492,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.17"
+version = "1.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
 dependencies = [
  "jobserver",
  "libc",
@@ -1670,25 +1724,13 @@ dependencies = [
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "fastcrypto 0.1.8",
- "mysten-network 0.2.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "rand 0.8.5",
- "serde",
- "shared-crypto 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
-]
-
-[[package]]
-name = "consensus-config"
-version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
  "fastcrypto 0.1.8",
- "mysten-network 0.2.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "mysten-network",
  "rand 0.8.5",
  "serde",
- "shared-crypto 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "shared-crypto",
 ]
 
 [[package]]
@@ -1831,9 +1873,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1995,12 +2037,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core 0.20.10",
- "darling_macro 0.20.10",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
 ]
 
 [[package]]
@@ -2019,9 +2061,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
@@ -2044,11 +2086,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core 0.20.10",
+ "darling_core 0.20.11",
  "quote",
  "syn 2.0.100",
 ]
@@ -2214,7 +2256,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling 0.20.10",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -2536,14 +2578,6 @@ dependencies = [
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "serde_yaml 0.8.26",
-]
-
-[[package]]
-name = "enum-compat-util"
-version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
  "serde_yaml 0.8.26",
@@ -2578,9 +2612,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -2625,9 +2659,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
@@ -2889,9 +2923,9 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -3225,7 +3259,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3234,9 +3268,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7db2ff139bba50379da6aa0766b52fdcb62cb5b263009b09ed58ba604e14bbd1"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -3459,13 +3493,13 @@ dependencies = [
 
 [[package]]
 name = "hostname"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9c7c7c8ac16c798734b8a24560c1362120597c40d5e1459f09498f8f6c8f2ba"
+checksum = "a56f203cd1c76362b69e3863fd987520ac36cf70a8c92627449b2f64a8cf7d65"
 dependencies = [
  "cfg-if",
  "libc",
- "windows 0.52.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -3609,9 +3643,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3619,6 +3653,7 @@ dependencies = [
  "http 1.3.1",
  "http-body",
  "hyper",
+ "libc",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -3628,16 +3663,17 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
- "windows-core 0.52.0",
+ "windows-core 0.61.0",
 ]
 
 [[package]]
@@ -3690,9 +3726,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locid_transform_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
 
 [[package]]
 name = "icu_normalizer"
@@ -3714,9 +3750,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
 
 [[package]]
 name = "icu_properties"
@@ -3735,9 +3771,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
 
 [[package]]
 name = "icu_provider"
@@ -3910,9 +3946,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -4083,10 +4119,11 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
+ "getrandom 0.3.2",
  "libc",
 ]
 
@@ -4826,9 +4863,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -4854,9 +4891,9 @@ checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
 
 [[package]]
 name = "log"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 dependencies = [
  "serde",
 ]
@@ -4953,6 +4990,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4992,9 +5035,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
@@ -5077,25 +5120,11 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-bytecode-verifier-meter 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
-]
-
-[[package]]
-name = "move-abstract-interpreter"
-version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-bytecode-verifier-meter 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-binary-format",
+ "move-bytecode-verifier-meter",
 ]
-
-[[package]]
-name = "move-abstract-stack"
-version = "0.0.1"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
 
 [[package]]
 name = "move-abstract-stack"
@@ -5105,35 +5134,16 @@ source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "anyhow",
- "enum-compat-util 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-proc-macros 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "ref-cast",
- "serde",
- "variant_count",
-]
-
-[[package]]
-name = "move-binary-format"
-version = "0.0.3"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
  "anyhow",
- "enum-compat-util 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-proc-macros 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "enum-compat-util",
+ "move-core-types",
+ "move-proc-macros",
  "ref-cast",
  "serde",
  "variant_count",
 ]
-
-[[package]]
-name = "move-borrow-graph"
-version = "0.0.1"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
 
 [[package]]
 name = "move-borrow-graph"
@@ -5143,31 +5153,15 @@ source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "anyhow",
- "bcs",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-ir-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-symbol-pool 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "move-bytecode-source-map"
-version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
  "anyhow",
  "bcs",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-ir-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-symbol-pool 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-binary-format",
+ "move-command-line-common",
+ "move-core-types",
+ "move-ir-types",
+ "move-symbol-pool",
  "serde",
  "serde_json",
 ]
@@ -5175,25 +5169,12 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "anyhow",
- "indexmap 2.8.0",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "petgraph",
- "serde-reflection",
-]
-
-[[package]]
-name = "move-bytecode-utils"
-version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
  "anyhow",
- "indexmap 2.8.0",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "indexmap 2.9.0",
+ "move-binary-format",
+ "move-core-types",
  "petgraph",
  "serde-reflection",
 ]
@@ -5201,41 +5182,16 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "move-abstract-interpreter 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-abstract-stack 0.0.1 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-borrow-graph 0.0.1 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-bytecode-verifier-meter 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-vm-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "petgraph",
-]
-
-[[package]]
-name = "move-bytecode-verifier"
-version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
- "move-abstract-interpreter 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-abstract-stack 0.0.1 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-borrow-graph 0.0.1 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-bytecode-verifier-meter 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-vm-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-abstract-interpreter",
+ "move-abstract-stack",
+ "move-binary-format",
+ "move-borrow-graph",
+ "move-bytecode-verifier-meter",
+ "move-core-types",
+ "move-vm-config",
  "petgraph",
-]
-
-[[package]]
-name = "move-bytecode-verifier-meter"
-version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-vm-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
 ]
 
 [[package]]
@@ -5243,29 +5199,9 @@ name = "move-bytecode-verifier-meter"
 version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-vm-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
-]
-
-[[package]]
-name = "move-command-line-common"
-version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "anyhow",
- "bcs",
- "colored 2.2.0",
- "dirs-next",
- "hex",
- "insta",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "once_cell",
- "serde",
- "sha2 0.9.9",
- "vfs",
- "walkdir",
+ "move-binary-format",
+ "move-core-types",
+ "move-vm-config",
 ]
 
 [[package]]
@@ -5279,8 +5215,8 @@ dependencies = [
  "dirs-next",
  "hex",
  "insta",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-binary-format",
+ "move-core-types",
  "once_cell",
  "packed_struct",
  "serde",
@@ -5292,41 +5228,6 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "anyhow",
- "bcs",
- "clap",
- "codespan-reporting",
- "dunce",
- "hex",
- "insta",
- "lsp-types",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-borrow-graph 0.0.1 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-ir-to-bytecode 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-ir-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-proc-macros 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-symbol-pool 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "once_cell",
- "petgraph",
- "rayon",
- "regex",
- "serde",
- "serde_json",
- "similar",
- "stacker",
- "tempfile",
- "vfs",
-]
-
-[[package]]
-name = "move-compiler"
-version = "0.0.1"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
  "anyhow",
@@ -5337,16 +5238,16 @@ dependencies = [
  "hex",
  "insta",
  "lsp-types",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-borrow-graph 0.0.1 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-ir-to-bytecode 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-ir-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-proc-macros 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-symbol-pool 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-binary-format",
+ "move-borrow-graph",
+ "move-bytecode-source-map",
+ "move-bytecode-verifier",
+ "move-command-line-common",
+ "move-core-types",
+ "move-ir-to-bytecode",
+ "move-ir-types",
+ "move-proc-macros",
+ "move-symbol-pool",
  "once_cell",
  "petgraph",
  "rayon",
@@ -5362,39 +5263,15 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "anyhow",
- "bcs",
- "enum-compat-util 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "ethnum",
- "hex",
- "leb128",
- "move-proc-macros 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "num",
- "once_cell",
- "primitive-types",
- "rand 0.8.5",
- "ref-cast",
- "serde",
- "serde_bytes",
- "serde_with",
- "thiserror 1.0.69",
- "uint 0.9.5",
-]
-
-[[package]]
-name = "move-core-types"
-version = "0.0.4"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
  "anyhow",
  "bcs",
- "enum-compat-util 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "enum-compat-util",
  "ethnum",
  "hex",
  "leb128",
- "move-proc-macros 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-proc-macros",
  "num",
  "once_cell",
  "primitive-types",
@@ -5410,27 +5287,6 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "anyhow",
- "bcs",
- "clap",
- "codespan",
- "colored 2.2.0",
- "indexmap 2.8.0",
- "move-abstract-interpreter 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-ir-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "petgraph",
- "serde",
-]
-
-[[package]]
-name = "move-coverage"
-version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
  "anyhow",
@@ -5438,36 +5294,15 @@ dependencies = [
  "clap",
  "codespan",
  "colored 2.2.0",
- "indexmap 2.8.0",
- "move-abstract-interpreter 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-ir-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "indexmap 2.9.0",
+ "move-abstract-interpreter",
+ "move-binary-format",
+ "move-bytecode-source-map",
+ "move-command-line-common",
+ "move-core-types",
+ "move-ir-types",
  "petgraph",
  "serde",
-]
-
-[[package]]
-name = "move-disassembler"
-version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "anyhow",
- "bcs",
- "clap",
- "hex",
- "inline_colorization",
- "move-abstract-interpreter 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-compiler 0.0.1 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-coverage 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-ir-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-symbol-pool 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
 ]
 
 [[package]]
@@ -5480,33 +5315,15 @@ dependencies = [
  "clap",
  "hex",
  "inline_colorization",
- "move-abstract-interpreter 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-compiler 0.0.1 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-coverage 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-ir-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-symbol-pool 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
-]
-
-[[package]]
-name = "move-ir-to-bytecode"
-version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "anyhow",
- "codespan-reporting",
- "log",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-ir-to-bytecode-syntax 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-ir-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-symbol-pool 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "ouroboros",
+ "move-abstract-interpreter",
+ "move-binary-format",
+ "move-bytecode-source-map",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-coverage",
+ "move-ir-types",
+ "move-symbol-pool",
 ]
 
 [[package]]
@@ -5517,53 +5334,27 @@ dependencies = [
  "anyhow",
  "codespan-reporting",
  "log",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-ir-to-bytecode-syntax 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-ir-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-symbol-pool 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-binary-format",
+ "move-bytecode-source-map",
+ "move-command-line-common",
+ "move-core-types",
+ "move-ir-to-bytecode-syntax",
+ "move-ir-types",
+ "move-symbol-pool",
  "ouroboros",
 ]
 
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "anyhow",
- "hex",
- "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-ir-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-symbol-pool 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
-]
-
-[[package]]
-name = "move-ir-to-bytecode-syntax"
-version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
  "anyhow",
  "hex",
- "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-ir-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-symbol-pool 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
-]
-
-[[package]]
-name = "move-ir-types"
-version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "hex",
- "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-symbol-pool 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "once_cell",
- "serde",
+ "move-command-line-common",
+ "move-core-types",
+ "move-ir-types",
+ "move-symbol-pool",
 ]
 
 [[package]]
@@ -5572,21 +5363,11 @@ version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
  "hex",
- "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-symbol-pool 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-command-line-common",
+ "move-core-types",
+ "move-symbol-pool",
  "once_cell",
  "serde",
-]
-
-[[package]]
-name = "move-proc-macros"
-version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "enum-compat-util 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "quote",
- "syn 2.0.100",
 ]
 
 [[package]]
@@ -5594,19 +5375,9 @@ name = "move-proc-macros"
 version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
- "enum-compat-util 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "enum-compat-util",
  "quote",
  "syn 2.0.100",
-]
-
-[[package]]
-name = "move-symbol-pool"
-version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "once_cell",
- "phf",
- "serde",
 ]
 
 [[package]]
@@ -5622,31 +5393,10 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "once_cell",
-]
-
-[[package]]
-name = "move-vm-config"
-version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-binary-format",
  "once_cell",
-]
-
-[[package]]
-name = "move-vm-profiler"
-version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "move-vm-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "once_cell",
- "serde",
- "serde_json",
- "tracing",
 ]
 
 [[package]]
@@ -5654,7 +5404,7 @@ name = "move-vm-profiler"
 version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
- "move-vm-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-vm-config",
  "once_cell",
  "serde",
  "serde_json",
@@ -5664,42 +5414,15 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "anyhow",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-vm-profiler 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-vm-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "once_cell",
- "serde",
-]
-
-[[package]]
-name = "move-vm-test-utils"
-version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
  "anyhow",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-vm-profiler 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-vm-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-binary-format",
+ "move-core-types",
+ "move-vm-profiler",
+ "move-vm-types",
  "once_cell",
  "serde",
-]
-
-[[package]]
-name = "move-vm-types"
-version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "bcs",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-vm-profiler 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "serde",
- "smallvec",
 ]
 
 [[package]]
@@ -5708,9 +5431,9 @@ version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
  "bcs",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-vm-profiler 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-binary-format",
+ "move-core-types",
+ "move-vm-profiler",
  "serde",
  "smallvec",
 ]
@@ -5827,25 +5550,6 @@ dependencies = [
 [[package]]
 name = "mysten-common"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "anyhow",
- "fastcrypto 0.1.8",
- "futures",
- "mysten-metrics 0.7.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "parking_lot",
- "prometheus",
- "reqwest",
- "snap",
- "sui-tls 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "mysten-common"
-version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
  "antithesis_sdk",
@@ -5853,16 +5557,16 @@ dependencies = [
  "either",
  "fastcrypto 0.1.8",
  "futures",
- "mysten-metrics 0.7.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "mysten-metrics",
  "once_cell",
  "parking_lot",
  "prometheus",
  "rand 0.8.5",
  "reqwest",
  "snap",
- "sui-macros 0.7.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "sui-tls 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-macros",
+ "sui-tls",
+ "sui-types",
  "tempfile",
  "tokio",
  "tracing",
@@ -5871,76 +5575,22 @@ dependencies = [
 [[package]]
 name = "mysten-metrics"
 version = "0.7.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "async-trait",
- "axum",
- "dashmap 5.5.3",
- "futures",
- "once_cell",
- "parking_lot",
- "prometheus",
- "prometheus-closure-metric 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "scopeguard",
- "simple-server-timing-header",
- "tap",
- "tokio",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "mysten-metrics"
-version = "0.7.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
  "async-trait",
- "axum",
+ "axum 0.7.9",
  "dashmap 5.5.3",
  "futures",
  "once_cell",
  "parking_lot",
  "prometheus",
- "prometheus-closure-metric 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "prometheus-closure-metric",
  "scopeguard",
  "simple-server-timing-header",
  "tap",
  "tokio",
  "tracing",
  "uuid",
-]
-
-[[package]]
-name = "mysten-network"
-version = "0.2.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "anemo",
- "anemo-tower",
- "async-stream",
- "bcs",
- "bytes",
- "eyre",
- "futures",
- "http 1.3.1",
- "http-body",
- "hyper-rustls",
- "hyper-util",
- "multiaddr 0.17.1",
- "once_cell",
- "pin-project-lite",
- "prometheus",
- "serde",
- "snap",
- "sui-http 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "tokio",
- "tokio-rustls",
- "tokio-stream",
- "tonic",
- "tonic-health",
- "tower 0.4.13",
- "tower-http 0.5.2",
- "tracing",
 ]
 
 [[package]]
@@ -5965,7 +5615,7 @@ dependencies = [
  "prometheus",
  "serde",
  "snap",
- "sui-http 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-http",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -6411,9 +6061,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.71"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",
@@ -6443,9 +6093,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.106"
+version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",
@@ -6698,7 +6348,7 @@ dependencies = [
  "data-encoding",
  "getrandom 0.2.15",
  "hmac",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -6782,9 +6432,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
+checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
 dependencies = [
  "memchr",
  "thiserror 2.0.12",
@@ -6793,9 +6443,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e"
+checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
 dependencies = [
  "pest",
  "pest_generator",
@@ -6803,9 +6453,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b"
+checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
 dependencies = [
  "pest",
  "pest_meta",
@@ -6816,9 +6466,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea"
+checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
 dependencies = [
  "once_cell",
  "pest",
@@ -7153,16 +6803,6 @@ dependencies = [
 [[package]]
 name = "prometheus-closure-metric"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "anyhow",
- "prometheus",
- "protobuf",
-]
-
-[[package]]
-name = "prometheus-closure-metric"
-version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
  "anyhow",
@@ -7296,9 +6936,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.2"
+version = "0.37.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165859e9e55f79d67b96c5d96f4e88b6f2695a1972849c15a6a3f5c59fc2c003"
+checksum = "a4ce8c88de324ff838700f36fb6ab86c96df0e3c4ab6ef3a9b2044465cce1369"
 dependencies = [
  "memchr",
  "serde",
@@ -7347,9 +6987,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e46f3055866785f6b92bc6164b76be02ca8f2eb4b002c0354b28cf4c119e5944"
+checksum = "541d0f57c6ec747a90738a52741d3221f7960e8ac2f0ff4b1a63680e033b4ab5"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -7530,9 +7170,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -7741,9 +7381,9 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.10.10"
+version = "0.10.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a652edd001c53df0b3f96a36a8dc93fce6866988efc16808235653c6bcac8bf2"
+checksum = "19e8d2cfa184d94d0726d650a9f4a1be7f9b76ac9fdb954219878dc00c1c1e7b"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -7937,28 +7577,28 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys 0.9.3",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.25"
+version = "0.23.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
+checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
 dependencies = [
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.0",
+ "rustls-webpki 0.103.1",
  "subtle",
  "zeroize",
 ]
@@ -8007,7 +7647,7 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.0",
+ "rustls-webpki 0.103.1",
  "security-framework 3.2.0",
  "security-framework-sys",
  "webpki-root-certs",
@@ -8032,9 +7672,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.0"
+version = "0.103.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa4eeac2588ffff23e9d7a7e9b3f971c5fb5b7ebc9452745e0c232c64f83b2f"
+checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -8314,7 +7954,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "itoa",
  "memchr",
  "ryu",
@@ -8373,7 +8013,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -8387,7 +8027,7 @@ version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
 dependencies = [
- "darling 0.20.10",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -8411,7 +8051,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "itoa",
  "ryu",
  "serde",
@@ -8495,18 +8135,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "shared-crypto"
-version = "0.0.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "bcs",
- "eyre",
- "fastcrypto 0.1.8",
- "serde",
- "serde_repr",
 ]
 
 [[package]]
@@ -8622,9 +8250,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 dependencies = [
  "serde",
 ]
@@ -8675,9 +8303,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -8780,7 +8408,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.2",
  "hashlink 0.10.0",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "log",
  "memchr",
  "native-tls",
@@ -8991,15 +8619,6 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-dependencies = [
- "strum_macros 0.24.3",
-]
-
-[[package]]
-name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
@@ -9014,19 +8633,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 dependencies = [
  "strum_macros 0.27.1",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -9070,18 +8676,18 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 [[package]]
 name = "sui-config"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
  "anemo",
  "anyhow",
  "bcs",
  "clap",
- "consensus-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "consensus-config",
  "csv",
  "dirs 4.0.0",
  "fastcrypto 0.1.8",
- "move-vm-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "mysten-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-vm-config",
+ "mysten-common",
  "nonzero_ext",
  "object_store",
  "once_cell",
@@ -9091,50 +8697,11 @@ dependencies = [
  "serde",
  "serde_with",
  "serde_yaml 0.8.26",
- "sui-keys 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "sui-protocol-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "sui-rpc-api 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "sui-keys",
+ "sui-protocol-config",
+ "sui-rpc-api",
+ "sui-types",
  "tracing",
-]
-
-[[package]]
-name = "sui-config"
-version = "0.0.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
-dependencies = [
- "anemo",
- "anyhow",
- "bcs",
- "clap",
- "consensus-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "csv",
- "dirs 4.0.0",
- "fastcrypto 0.1.8",
- "move-vm-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "mysten-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "nonzero_ext",
- "object_store",
- "once_cell",
- "prometheus",
- "rand 0.8.5",
- "reqwest",
- "serde",
- "serde_with",
- "serde_yaml 0.8.26",
- "sui-keys 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "sui-protocol-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "sui-rpc-api 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "tracing",
-]
-
-[[package]]
-name = "sui-enum-compat-util"
-version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "serde_yaml 0.8.26",
 ]
 
 [[package]]
@@ -9143,26 +8710,6 @@ version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
  "serde_yaml 0.8.26",
-]
-
-[[package]]
-name = "sui-http"
-version = "0.0.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "bytes",
- "http 1.3.1",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "tower 0.4.13",
- "tracing",
 ]
 
 [[package]]
@@ -9188,55 +8735,18 @@ dependencies = [
 [[package]]
 name = "sui-json"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "anyhow",
- "bcs",
- "fastcrypto 0.1.8",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "schemars",
- "serde",
- "serde_json",
- "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
-]
-
-[[package]]
-name = "sui-json"
-version = "0.0.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
  "anyhow",
  "bcs",
  "fastcrypto 0.1.8",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-core-types",
  "schemars",
  "serde",
  "serde_json",
- "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
-]
-
-[[package]]
-name = "sui-json-rpc-api"
-version = "0.0.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "anyhow",
- "fastcrypto 0.1.8",
- "jsonrpsee",
- "mysten-metrics 0.7.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "once_cell",
- "prometheus",
- "sui-json 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "sui-json-rpc-types 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "sui-open-rpc 1.45.2",
- "sui-open-rpc-macros 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "tap",
- "tracing",
+ "sui-types",
 ]
 
 [[package]]
@@ -9247,47 +8757,15 @@ dependencies = [
  "anyhow",
  "fastcrypto 0.1.8",
  "jsonrpsee",
- "mysten-metrics 0.7.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "mysten-metrics",
  "once_cell",
  "prometheus",
- "sui-json 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "sui-json-rpc-types 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "sui-open-rpc 1.46.2",
- "sui-open-rpc-macros 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-json",
+ "sui-json-rpc-types",
+ "sui-open-rpc",
+ "sui-open-rpc-macros",
+ "sui-types",
  "tap",
- "tracing",
-]
-
-[[package]]
-name = "sui-json-rpc-types"
-version = "0.0.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "anyhow",
- "bcs",
- "colored 2.2.0",
- "enum_dispatch",
- "fastcrypto 0.1.8",
- "itertools 0.13.0",
- "json_to_table",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-disassembler 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-ir-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "mysten-metrics 0.7.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "schemars",
- "serde",
- "serde_json",
- "serde_with",
- "sui-enum-compat-util 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "sui-json 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "sui-macros 0.7.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "sui-package-resolver 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "sui-protocol-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "tabled",
  "tracing",
 ]
 
@@ -9303,22 +8781,22 @@ dependencies = [
  "fastcrypto 0.1.8",
  "itertools 0.13.0",
  "json_to_table",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-disassembler 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-ir-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "mysten-metrics 0.7.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-core-types",
+ "move-disassembler",
+ "move-ir-types",
+ "mysten-metrics",
  "schemars",
  "serde",
  "serde_json",
  "serde_with",
- "sui-enum-compat-util 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "sui-json 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "sui-macros 0.7.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "sui-package-resolver 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "sui-protocol-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-enum-compat-util",
+ "sui-json",
+ "sui-macros",
+ "sui-package-resolver",
+ "sui-protocol-config",
+ "sui-types",
  "tabled",
  "tracing",
 ]
@@ -9326,25 +8804,6 @@ dependencies = [
 [[package]]
 name = "sui-keys"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "anyhow",
- "bip32",
- "fastcrypto 0.1.8",
- "rand 0.8.5",
- "regex",
- "serde",
- "serde_json",
- "shared-crypto 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "signature 1.6.4",
- "slip10_ed25519",
- "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "tiny-bip39",
-]
-
-[[package]]
-name = "sui-keys"
-version = "0.0.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
  "anyhow",
@@ -9354,22 +8813,11 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "shared-crypto 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "shared-crypto",
  "signature 1.6.4",
  "slip10_ed25519",
- "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-types",
  "tiny-bip39",
-]
-
-[[package]]
-name = "sui-macros"
-version = "0.7.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "futures",
- "once_cell",
- "sui-proc-macros 0.7.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "tracing",
 ]
 
 [[package]]
@@ -9379,20 +8827,8 @@ source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d
 dependencies = [
  "futures",
  "once_cell",
- "sui-proc-macros 0.7.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-proc-macros",
  "tracing",
-]
-
-[[package]]
-name = "sui-open-rpc"
-version = "1.45.2"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "bcs",
- "schemars",
- "serde",
- "serde_json",
- "versions",
 ]
 
 [[package]]
@@ -9410,19 +8846,6 @@ dependencies = [
 [[package]]
 name = "sui-open-rpc-macros"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "derive-syn-parse",
- "itertools 0.13.0",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unescape",
-]
-
-[[package]]
-name = "sui-open-rpc-macros"
-version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
  "derive-syn-parse",
@@ -9436,51 +8859,20 @@ dependencies = [
 [[package]]
 name = "sui-package-resolver"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "async-trait",
- "bcs",
- "eyre",
- "lru 0.10.1",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "serde",
- "sui-rpc-api 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "thiserror 1.0.69",
- "tokio",
-]
-
-[[package]]
-name = "sui-package-resolver"
-version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
  "async-trait",
  "bcs",
  "eyre",
  "lru 0.10.1",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-binary-format",
+ "move-command-line-common",
+ "move-core-types",
  "serde",
- "sui-rpc-api 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-rpc-api",
+ "sui-types",
  "thiserror 1.0.69",
  "tokio",
-]
-
-[[package]]
-name = "sui-proc-macros"
-version = "0.7.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "msim-macros",
- "proc-macro2",
- "quote",
- "sui-enum-compat-util 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "syn 2.0.100",
 ]
 
 [[package]]
@@ -9491,24 +8883,8 @@ dependencies = [
  "msim-macros",
  "proc-macro2",
  "quote",
- "sui-enum-compat-util 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-enum-compat-util",
  "syn 2.0.100",
-]
-
-[[package]]
-name = "sui-protocol-config"
-version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "clap",
- "insta",
- "move-vm-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "schemars",
- "serde",
- "serde-env",
- "serde_with",
- "sui-protocol-config-macros 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "tracing",
 ]
 
 [[package]]
@@ -9518,23 +8894,13 @@ source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d
 dependencies = [
  "clap",
  "insta",
- "move-vm-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-vm-config",
  "schemars",
  "serde",
  "serde-env",
  "serde_with",
- "sui-protocol-config-macros 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-protocol-config-macros",
  "tracing",
-]
-
-[[package]]
-name = "sui-protocol-config-macros"
-version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -9550,55 +8916,12 @@ dependencies = [
 [[package]]
 name = "sui-rpc-api"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "anyhow",
- "async-stream",
- "async-trait",
- "axum",
- "base64 0.21.7",
- "bcs",
- "bytes",
- "fastcrypto 0.1.8",
- "http 1.3.1",
- "itertools 0.13.0",
- "mime",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "mysten-network 0.2.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "prometheus",
- "prost",
- "prost-types",
- "rand 0.8.5",
- "roaring",
- "serde",
- "serde_json",
- "serde_with",
- "sui-protocol-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "sui-sdk-types 0.0.2 (git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5e11579031793f086178332219f5847ec94da0c4)",
- "sui-transaction-builder 0.1.0",
- "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "tap",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
- "tonic",
- "tonic-health",
- "tonic-reflection",
- "tower 0.4.13",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "sui-rpc-api"
-version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
  "anyhow",
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.7.9",
  "base64 0.21.7",
  "bcs",
  "bytes",
@@ -9606,9 +8929,9 @@ dependencies = [
  "http 1.3.1",
  "itertools 0.13.0",
  "mime",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "mysten-network 0.2.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-binary-format",
+ "move-core-types",
+ "mysten-network",
  "prometheus",
  "prost",
  "prost-types",
@@ -9617,10 +8940,10 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "sui-protocol-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-protocol-config",
  "sui-sdk-types 0.0.4",
  "sui-transaction-builder 0.0.4",
- "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-types",
  "tap",
  "thiserror 1.0.69",
  "tokio",
@@ -9631,39 +8954,6 @@ dependencies = [
  "tower 0.4.13",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "sui-sdk"
-version = "1.45.2"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "anyhow",
- "async-trait",
- "base64 0.21.7",
- "bcs",
- "clap",
- "colored 2.2.0",
- "fastcrypto 0.1.8",
- "futures",
- "futures-core",
- "jsonrpsee",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "reqwest",
- "serde",
- "serde_json",
- "serde_with",
- "shared-crypto 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "sui-config 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "sui-json 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "sui-json-rpc-api 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "sui-json-rpc-types 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "sui-keys 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "sui-transaction-builder 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -9681,19 +8971,19 @@ dependencies = [
  "futures",
  "futures-core",
  "jsonrpsee",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-core-types",
  "reqwest",
  "serde",
  "serde_json",
  "serde_with",
- "shared-crypto 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "sui-config 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "sui-json 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "sui-json-rpc-api 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "sui-json-rpc-types 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "sui-keys 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "sui-transaction-builder 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "shared-crypto",
+ "sui-config",
+ "sui-json",
+ "sui-json-rpc-api",
+ "sui-json-rpc-types",
+ "sui-keys",
+ "sui-transaction-builder 0.0.0",
+ "sui-types",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -9720,25 +9010,6 @@ dependencies = [
 
 [[package]]
 name = "sui-sdk-types"
-version = "0.0.2"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5e11579031793f086178332219f5847ec94da0c4#5e11579031793f086178332219f5847ec94da0c4"
-dependencies = [
- "base64ct",
- "bcs",
- "blake2",
- "bnum",
- "bs58 0.5.1",
- "hex",
- "roaring",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_with",
- "winnow 0.7.4",
-]
-
-[[package]]
-name = "sui-sdk-types"
 version = "0.0.4"
 source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=83ff809bc11cbabda21b60130e1f5420170548bf#83ff809bc11cbabda21b60130e1f5420170548bf"
 dependencies = [
@@ -9753,29 +9024,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_with",
- "winnow 0.7.4",
-]
-
-[[package]]
-name = "sui-tls"
-version = "0.0.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "anyhow",
- "arc-swap",
- "axum",
- "axum-server",
- "ed25519",
- "fastcrypto 0.1.8",
- "pkcs8 0.10.2",
- "rcgen",
- "reqwest",
- "rustls",
- "rustls-webpki 0.103.0",
- "tokio",
- "tokio-rustls",
- "tower-layer",
- "x509-parser 0.17.0",
+ "winnow 0.7.6",
 ]
 
 [[package]]
@@ -9785,7 +9034,7 @@ source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d
 dependencies = [
  "anyhow",
  "arc-swap",
- "axum",
+ "axum 0.7.9",
  "axum-server",
  "ed25519",
  "fastcrypto 0.1.8",
@@ -9793,28 +9042,11 @@ dependencies = [
  "rcgen",
  "reqwest",
  "rustls",
- "rustls-webpki 0.103.0",
+ "rustls-webpki 0.103.1",
  "tokio",
  "tokio-rustls",
  "tower-layer",
  "x509-parser 0.17.0",
-]
-
-[[package]]
-name = "sui-transaction-builder"
-version = "0.0.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "anyhow",
- "async-trait",
- "bcs",
- "futures",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "sui-json 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "sui-json-rpc-types 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "sui-protocol-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
 ]
 
 [[package]]
@@ -9826,12 +9058,12 @@ dependencies = [
  "async-trait",
  "bcs",
  "futures",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "sui-json 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "sui-json-rpc-types 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "sui-protocol-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-binary-format",
+ "move-core-types",
+ "sui-json",
+ "sui-json-rpc-types",
+ "sui-protocol-config",
+ "sui-types",
 ]
 
 [[package]]
@@ -9849,88 +9081,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sui-transaction-builder"
-version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5e11579031793f086178332219f5847ec94da0c4#5e11579031793f086178332219f5847ec94da0c4"
-dependencies = [
- "base64ct",
- "bcs",
- "serde",
- "serde_json",
- "serde_with",
- "sui-sdk-types 0.0.2 (git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5e11579031793f086178332219f5847ec94da0c4)",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "sui-types"
-version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "anemo",
- "anyhow",
- "async-trait",
- "bcs",
- "better_any",
- "bincode",
- "byteorder",
- "chrono",
- "ciborium",
- "consensus-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "derive_more 1.0.0",
- "enum_dispatch",
- "eyre",
- "fastcrypto 0.1.8",
- "fastcrypto-tbls",
- "fastcrypto-zkp",
- "im",
- "indexmap 2.8.0",
- "itertools 0.13.0",
- "lru 0.10.1",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-vm-profiler 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "move-vm-test-utils 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "mysten-metrics 0.7.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "mysten-network 0.2.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "nonempty",
- "num-bigint 0.4.6",
- "num-traits",
- "num_enum",
- "once_cell",
- "p384",
- "parking_lot",
- "passkey-types",
- "prometheus",
- "proptest",
- "proptest-derive",
- "rand 0.8.5",
- "roaring",
- "rustls-pemfile",
- "schemars",
- "serde",
- "serde-name",
- "serde_json",
- "serde_with",
- "shared-crypto 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "signature 1.6.4",
- "static_assertions",
- "strum 0.24.1",
- "strum_macros 0.24.3",
- "sui-enum-compat-util 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "sui-macros 0.7.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "sui-protocol-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "sui-sdk-types 0.0.2 (git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5e11579031793f086178332219f5847ec94da0c4)",
- "tap",
- "thiserror 1.0.69",
- "tonic",
- "tracing",
- "typed-store-error 0.4.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
- "x509-parser 0.17.0",
-]
-
-[[package]]
 name = "sui-types"
 version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
@@ -9944,7 +9094,7 @@ dependencies = [
  "byteorder",
  "chrono",
  "ciborium",
- "consensus-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "consensus-config",
  "derive_more 1.0.0",
  "enum_dispatch",
  "eyre",
@@ -9952,16 +9102,16 @@ dependencies = [
  "fastcrypto-tbls",
  "fastcrypto-zkp",
  "im",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "itertools 0.13.0",
  "lru 0.10.1",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-vm-profiler 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "move-vm-test-utils 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "mysten-metrics 0.7.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "mysten-network 0.2.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-core-types",
+ "move-vm-profiler",
+ "move-vm-test-utils",
+ "mysten-metrics",
+ "mysten-network",
  "nonempty",
  "num-bigint 0.4.6",
  "num-traits",
@@ -9981,20 +9131,20 @@ dependencies = [
  "serde-name",
  "serde_json",
  "serde_with",
- "shared-crypto 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "shared-crypto",
  "signature 1.6.4",
  "static_assertions",
  "strum 0.27.1",
  "strum_macros 0.27.1",
- "sui-enum-compat-util 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "sui-macros 0.7.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
- "sui-protocol-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-enum-compat-util",
+ "sui-macros",
+ "sui-protocol-config",
  "sui-sdk-types 0.0.4",
  "tap",
  "thiserror 1.0.69",
  "tonic",
  "tracing",
- "typed-store-error 0.4.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "typed-store-error",
  "x509-parser 0.17.0",
 ]
 
@@ -10132,7 +9282,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.3",
+ "rustix 1.0.5",
  "windows-sys 0.59.0",
 ]
 
@@ -10151,7 +9301,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
- "rustix 1.0.3",
+ "rustix 1.0.5",
  "windows-sys 0.59.0",
 ]
 
@@ -10216,9 +9366,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.40"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d9c75b47bdff86fa3334a3db91356b8d7d86a9b839dab7d0bdc5c3d3a077618"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
@@ -10237,9 +9387,9 @@ checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29aa485584182073ed57fd5004aa09c371f021325014694e432313345865fd04"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
@@ -10453,11 +9603,11 @@ version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.7.4",
+ "winnow 0.7.6",
 ]
 
 [[package]]
@@ -10468,7 +9618,7 @@ checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.7.9",
  "base64 0.22.1",
  "bytes",
  "h2",
@@ -10780,15 +9930,6 @@ dependencies = [
 [[package]]
 name = "typed-store-error"
 version = "0.4.0"
-source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
-dependencies = [
- "serde",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "typed-store-error"
-version = "0.4.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
  "serde",
@@ -11038,7 +10179,7 @@ version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435c6f69ef38c9017b4b4eea965dfb91e71e53d869e896db40d1cf2441dd75c0"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -11058,11 +10199,11 @@ dependencies = [
 
 [[package]]
 name = "utoipa-swagger-ui"
-version = "8.1.0"
+version = "9.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4b5ac679cc6dfc5ea3f2823b0291c777750ffd5e13b21137e0f7ac0e8f9617"
+checksum = "d29519b3c485df6b13f4478ac909a491387e9ef70204487c3b64b53749aec0be"
 dependencies = [
- "axum",
+ "axum 0.8.3",
  "base64 0.22.1",
  "mime_guess",
  "regex",
@@ -11106,7 +10247,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7df16e474ef958526d1205f6dda359fdfab79d9aa6d54bafcb92dcd07673dca"
 dependencies = [
- "darling 0.20.10",
+ "darling 0.20.11",
  "once_cell",
  "proc-macro-error2",
  "proc-macro2",
@@ -11331,9 +10472,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
+checksum = "6994d13118ab492c3c80c1f81928718159254c53c472bf9ce36f8dae4add02a7"
 dependencies = [
  "redox_syscall",
  "wasite",
@@ -11378,16 +10519,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
-dependencies = [
- "windows-core 0.52.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efc5cf48f83140dcaab716eeaea345f9e93d0018fb81162753a3f76c3397b538"
@@ -11413,15 +10544,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
  "windows-core 0.58.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
  "windows-targets 0.52.6",
 ]
 
@@ -11461,6 +10583,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+dependencies = [
+ "windows-implement 0.60.0",
+ "windows-interface 0.59.1",
+ "windows-link",
+ "windows-result 0.3.2",
+ "windows-strings 0.4.0",
+]
+
+[[package]]
 name = "windows-implement"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11483,6 +10618,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "windows-interface"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11498,6 +10644,17 @@ name = "windows-interface"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11563,6 +10720,15 @@ name = "windows-strings"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
 dependencies = [
  "windows-link",
 ]
@@ -11856,9 +11022,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
 dependencies = [
  "memchr",
 ]
@@ -11888,7 +11054,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76ff259533532054cfbaefb115c613203c73707017459206380f03b3b3f266e"
 dependencies = [
- "darling 0.20.10",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -11970,9 +11136,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b940ebc25896e71dd073bad2dbaa2abfe97b0a391415e22ad1326d9c54e3c4"
+checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
 
 [[package]]
 name = "xmltree"
@@ -12172,18 +11338,16 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.4.2"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+checksum = "1dcb24d0152526ae49b9b96c1dcf71850ca1e0b882e4e28ed898a93c41334744"
 dependencies = [
  "arbitrary",
  "crc32fast",
  "crossbeam-utils",
- "displaydoc",
  "flate2",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "memchr",
- "thiserror 2.0.12",
  "zopfli",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "antithesis_sdk"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "201eba73b76341631014baf9c0018e703af204a1e0f15d7664d8a0947f6be74d"
+dependencies = [
+ "libc",
+ "libloading",
+ "linkme",
+ "once_cell",
+ "rand 0.8.5",
+ "rustc_version_runtime",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,9 +707,9 @@ dependencies = [
  "rsa 0.9.8",
  "serde",
  "serde_json",
- "shared-crypto",
- "sui-keys",
- "sui-sdk",
+ "shared-crypto 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-keys 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-sdk 1.46.2",
  "sui-sdk-types 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 2.0.12",
  "tokio",
@@ -721,8 +737,8 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sui-keys",
- "sui-sdk",
+ "sui-keys 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "sui-sdk 1.45.2",
  "sysinfo",
  "thiserror 2.0.12",
  "tokio",
@@ -763,8 +779,8 @@ dependencies = [
  "serde_json",
  "serde_yaml 0.9.34+deprecated",
  "sqlx",
- "sui-keys",
- "sui-sdk",
+ "sui-keys 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-sdk 1.46.2",
  "thiserror 2.0.12",
  "tokenizers",
  "tokio",
@@ -799,7 +815,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml 0.9.34+deprecated",
- "sui-sdk",
+ "sui-sdk 1.46.2",
  "thiserror 2.0.12",
  "tokio",
  "tower-http 0.6.2",
@@ -855,7 +871,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
- "sui-sdk",
+ "sui-sdk 1.45.2",
  "thiserror 2.0.12",
  "tokio",
  "toml 0.8.20",
@@ -877,7 +893,7 @@ dependencies = [
  "rand 0.8.5",
  "serde_json",
  "sha2 0.10.8",
- "sui-sdk",
+ "sui-sdk 1.45.2",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -1657,10 +1673,22 @@ version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
 dependencies = [
  "fastcrypto 0.1.8",
- "mysten-network",
+ "mysten-network 0.2.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
  "rand 0.8.5",
  "serde",
- "shared-crypto",
+ "shared-crypto 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+]
+
+[[package]]
+name = "consensus-config"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "fastcrypto 0.1.8",
+ "mysten-network 0.2.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "rand 0.8.5",
+ "serde",
+ "shared-crypto 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
 ]
 
 [[package]]
@@ -2509,6 +2537,14 @@ dependencies = [
 name = "enum-compat-util"
 version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
+dependencies = [
+ "serde_yaml 0.8.26",
+]
+
+[[package]]
+name = "enum-compat-util"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -4763,6 +4799,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
+name = "linkme"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22d227772b5999ddc0690e733f734f95ca05387e329c4084fe65678c51198ffe"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71a98813fa0073a317ed6a8055dcd4722a49d9b862af828ee68449adb799b6be"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5023,8 +5079,17 @@ name = "move-abstract-interpreter"
 version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
 dependencies = [
- "move-binary-format",
- "move-bytecode-verifier-meter",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-bytecode-verifier-meter 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+]
+
+[[package]]
+name = "move-abstract-interpreter"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-bytecode-verifier-meter 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
 ]
 
 [[package]]
@@ -5033,14 +5098,33 @@ version = "0.0.1"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
 
 [[package]]
+name = "move-abstract-stack"
+version = "0.0.1"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+
+[[package]]
 name = "move-binary-format"
 version = "0.0.3"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
 dependencies = [
  "anyhow",
- "enum-compat-util",
- "move-core-types",
- "move-proc-macros",
+ "enum-compat-util 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-proc-macros 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "ref-cast",
+ "serde",
+ "variant_count",
+]
+
+[[package]]
+name = "move-binary-format"
+version = "0.0.3"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "anyhow",
+ "enum-compat-util 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-proc-macros 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
  "ref-cast",
  "serde",
  "variant_count",
@@ -5052,17 +5136,38 @@ version = "0.0.1"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
 
 [[package]]
+name = "move-borrow-graph"
+version = "0.0.1"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+
+[[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
 dependencies = [
  "anyhow",
  "bcs",
- "move-binary-format",
- "move-command-line-common",
- "move-core-types",
- "move-ir-types",
- "move-symbol-pool",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-ir-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "move-bytecode-source-map"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "anyhow",
+ "bcs",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-ir-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
  "serde",
  "serde_json",
 ]
@@ -5074,8 +5179,21 @@ source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96b
 dependencies = [
  "anyhow",
  "indexmap 2.8.0",
- "move-binary-format",
- "move-core-types",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "petgraph",
+ "serde-reflection",
+]
+
+[[package]]
+name = "move-bytecode-utils"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "anyhow",
+ "indexmap 2.8.0",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
  "petgraph",
  "serde-reflection",
 ]
@@ -5085,13 +5203,28 @@ name = "move-bytecode-verifier"
 version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
 dependencies = [
- "move-abstract-interpreter",
- "move-abstract-stack",
- "move-binary-format",
- "move-borrow-graph",
- "move-bytecode-verifier-meter",
- "move-core-types",
- "move-vm-config",
+ "move-abstract-interpreter 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-abstract-stack 0.0.1 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-borrow-graph 0.0.1 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-bytecode-verifier-meter 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-vm-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "petgraph",
+]
+
+[[package]]
+name = "move-bytecode-verifier"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "move-abstract-interpreter 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-abstract-stack 0.0.1 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-borrow-graph 0.0.1 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-bytecode-verifier-meter 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-vm-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
  "petgraph",
 ]
 
@@ -5100,9 +5233,19 @@ name = "move-bytecode-verifier-meter"
 version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
 dependencies = [
- "move-binary-format",
- "move-core-types",
- "move-vm-config",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-vm-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+]
+
+[[package]]
+name = "move-bytecode-verifier-meter"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-vm-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
 ]
 
 [[package]]
@@ -5116,9 +5259,30 @@ dependencies = [
  "dirs-next",
  "hex",
  "insta",
- "move-binary-format",
- "move-core-types",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
  "once_cell",
+ "serde",
+ "sha2 0.9.9",
+ "vfs",
+ "walkdir",
+]
+
+[[package]]
+name = "move-command-line-common"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "anyhow",
+ "bcs",
+ "colored 2.2.0",
+ "dirs-next",
+ "hex",
+ "insta",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "once_cell",
+ "packed_struct",
  "serde",
  "sha2 0.9.9",
  "vfs",
@@ -5138,16 +5302,51 @@ dependencies = [
  "hex",
  "insta",
  "lsp-types",
- "move-binary-format",
- "move-borrow-graph",
- "move-bytecode-source-map",
- "move-bytecode-verifier",
- "move-command-line-common",
- "move-core-types",
- "move-ir-to-bytecode",
- "move-ir-types",
- "move-proc-macros",
- "move-symbol-pool",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-borrow-graph 0.0.1 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-bytecode-verifier 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-ir-to-bytecode 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-ir-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-proc-macros 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "once_cell",
+ "petgraph",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "similar",
+ "stacker",
+ "tempfile",
+ "vfs",
+]
+
+[[package]]
+name = "move-compiler"
+version = "0.0.1"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "anyhow",
+ "bcs",
+ "clap",
+ "codespan-reporting",
+ "dunce",
+ "hex",
+ "insta",
+ "lsp-types",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-borrow-graph 0.0.1 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-bytecode-verifier 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-ir-to-bytecode 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-ir-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-proc-macros 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
  "once_cell",
  "petgraph",
  "rayon",
@@ -5167,11 +5366,35 @@ source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96b
 dependencies = [
  "anyhow",
  "bcs",
- "enum-compat-util",
+ "enum-compat-util 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
  "ethnum",
  "hex",
  "leb128",
- "move-proc-macros",
+ "move-proc-macros 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "num",
+ "once_cell",
+ "primitive-types",
+ "rand 0.8.5",
+ "ref-cast",
+ "serde",
+ "serde_bytes",
+ "serde_with",
+ "thiserror 1.0.69",
+ "uint 0.9.5",
+]
+
+[[package]]
+name = "move-core-types"
+version = "0.0.4"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "anyhow",
+ "bcs",
+ "enum-compat-util 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "ethnum",
+ "hex",
+ "leb128",
+ "move-proc-macros 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
  "num",
  "once_cell",
  "primitive-types",
@@ -5195,12 +5418,33 @@ dependencies = [
  "codespan",
  "colored 2.2.0",
  "indexmap 2.8.0",
- "move-abstract-interpreter",
- "move-binary-format",
- "move-bytecode-source-map",
- "move-command-line-common",
- "move-core-types",
- "move-ir-types",
+ "move-abstract-interpreter 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-ir-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "petgraph",
+ "serde",
+]
+
+[[package]]
+name = "move-coverage"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "anyhow",
+ "bcs",
+ "clap",
+ "codespan",
+ "colored 2.2.0",
+ "indexmap 2.8.0",
+ "move-abstract-interpreter 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-ir-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
  "petgraph",
  "serde",
 ]
@@ -5215,15 +5459,36 @@ dependencies = [
  "clap",
  "hex",
  "inline_colorization",
- "move-abstract-interpreter",
- "move-binary-format",
- "move-bytecode-source-map",
- "move-command-line-common",
- "move-compiler",
- "move-core-types",
- "move-coverage",
- "move-ir-types",
- "move-symbol-pool",
+ "move-abstract-interpreter 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-compiler 0.0.1 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-coverage 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-ir-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+]
+
+[[package]]
+name = "move-disassembler"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "anyhow",
+ "bcs",
+ "clap",
+ "hex",
+ "inline_colorization",
+ "move-abstract-interpreter 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-compiler 0.0.1 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-coverage 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-ir-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
 ]
 
 [[package]]
@@ -5234,13 +5499,31 @@ dependencies = [
  "anyhow",
  "codespan-reporting",
  "log",
- "move-binary-format",
- "move-bytecode-source-map",
- "move-command-line-common",
- "move-core-types",
- "move-ir-to-bytecode-syntax",
- "move-ir-types",
- "move-symbol-pool",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-ir-to-bytecode-syntax 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-ir-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "ouroboros",
+]
+
+[[package]]
+name = "move-ir-to-bytecode"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "anyhow",
+ "codespan-reporting",
+ "log",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-ir-to-bytecode-syntax 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-ir-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
  "ouroboros",
 ]
 
@@ -5251,10 +5534,23 @@ source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96b
 dependencies = [
  "anyhow",
  "hex",
- "move-command-line-common",
- "move-core-types",
- "move-ir-types",
- "move-symbol-pool",
+ "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-ir-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+]
+
+[[package]]
+name = "move-ir-to-bytecode-syntax"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "anyhow",
+ "hex",
+ "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-ir-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
 ]
 
 [[package]]
@@ -5263,9 +5559,22 @@ version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
 dependencies = [
  "hex",
- "move-command-line-common",
- "move-core-types",
- "move-symbol-pool",
+ "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
+name = "move-ir-types"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "hex",
+ "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
  "once_cell",
  "serde",
 ]
@@ -5275,7 +5584,17 @@ name = "move-proc-macros"
 version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
 dependencies = [
- "enum-compat-util",
+ "enum-compat-util 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "move-proc-macros"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "enum-compat-util 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
  "quote",
  "syn 2.0.100",
 ]
@@ -5291,11 +5610,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "move-symbol-pool"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "once_cell",
+ "phf",
+ "serde",
+]
+
+[[package]]
 name = "move-vm-config"
 version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
 dependencies = [
- "move-binary-format",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "once_cell",
+]
+
+[[package]]
+name = "move-vm-config"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
  "once_cell",
 ]
 
@@ -5304,7 +5642,19 @@ name = "move-vm-profiler"
 version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
 dependencies = [
- "move-vm-config",
+ "move-vm-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
+name = "move-vm-profiler"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "move-vm-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
  "once_cell",
  "serde",
  "serde_json",
@@ -5317,10 +5667,24 @@ version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
 dependencies = [
  "anyhow",
- "move-binary-format",
- "move-core-types",
- "move-vm-profiler",
- "move-vm-types",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-vm-profiler 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-vm-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
+name = "move-vm-test-utils"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "anyhow",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-vm-profiler 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-vm-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
  "once_cell",
  "serde",
 ]
@@ -5331,9 +5695,22 @@ version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
 dependencies = [
  "bcs",
- "move-binary-format",
- "move-core-types",
- "move-vm-profiler",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-vm-profiler 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "move-vm-types"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "bcs",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-vm-profiler 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
  "serde",
  "smallvec",
 ]
@@ -5455,13 +5832,38 @@ dependencies = [
  "anyhow",
  "fastcrypto 0.1.8",
  "futures",
- "mysten-metrics",
+ "mysten-metrics 0.7.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
  "parking_lot",
  "prometheus",
  "reqwest",
  "snap",
- "sui-tls",
- "sui-types",
+ "sui-tls 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "mysten-common"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "antithesis_sdk",
+ "anyhow",
+ "either",
+ "fastcrypto 0.1.8",
+ "futures",
+ "mysten-metrics 0.7.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "once_cell",
+ "parking_lot",
+ "prometheus",
+ "rand 0.8.5",
+ "reqwest",
+ "snap",
+ "sui-macros 0.7.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-tls 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "tempfile",
  "tokio",
  "tracing",
 ]
@@ -5478,7 +5880,28 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "prometheus",
- "prometheus-closure-metric",
+ "prometheus-closure-metric 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "scopeguard",
+ "simple-server-timing-header",
+ "tap",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "mysten-metrics"
+version = "0.7.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "async-trait",
+ "axum",
+ "dashmap 5.5.3",
+ "futures",
+ "once_cell",
+ "parking_lot",
+ "prometheus",
+ "prometheus-closure-metric 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
  "scopeguard",
  "simple-server-timing-header",
  "tap",
@@ -5509,7 +5932,40 @@ dependencies = [
  "prometheus",
  "serde",
  "snap",
- "sui-http",
+ "sui-http 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tonic",
+ "tonic-health",
+ "tower 0.4.13",
+ "tower-http 0.5.2",
+ "tracing",
+]
+
+[[package]]
+name = "mysten-network"
+version = "0.2.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "anemo",
+ "anemo-tower",
+ "async-stream",
+ "bcs",
+ "bytes",
+ "eyre",
+ "futures",
+ "http 1.3.1",
+ "http-body",
+ "hyper-rustls",
+ "hyper-util",
+ "multiaddr 0.17.1",
+ "once_cell",
+ "pin-project-lite",
+ "prometheus",
+ "serde",
+ "snap",
+ "sui-http 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -6134,6 +6590,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "packed_struct"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36b29691432cc9eff8b282278473b63df73bea49bc3ec5e67f31a3ae9c3ec190"
+dependencies = [
+ "bitvec 1.0.1",
+ "packed_struct_codegen",
+ "serde",
+]
+
+[[package]]
+name = "packed_struct_codegen"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd6706dfe50d53e0f6aa09e12c034c44faacd23e966ae5a209e8bdb8f179f98"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "pairing"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6676,6 +7154,16 @@ dependencies = [
 name = "prometheus-closure-metric"
 version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
+dependencies = [
+ "anyhow",
+ "prometheus",
+ "protobuf",
+]
+
+[[package]]
+name = "prometheus-closure-metric"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -7416,6 +7904,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version_runtime"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
+dependencies = [
+ "rustc_version",
+ "semver",
+]
+
+[[package]]
 name = "rusticata-macros"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8012,6 +8510,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared-crypto"
+version = "0.0.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "bcs",
+ "eyre",
+ "fastcrypto 0.1.8",
+ "serde",
+ "serde_repr",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8498,6 +9008,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+dependencies = [
+ "strum_macros 0.27.1",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8517,6 +9036,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
  "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+dependencies = [
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -8544,12 +9076,12 @@ dependencies = [
  "anyhow",
  "bcs",
  "clap",
- "consensus-config",
+ "consensus-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
  "csv",
  "dirs 4.0.0",
  "fastcrypto 0.1.8",
- "move-vm-config",
- "mysten-common",
+ "move-vm-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "mysten-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
  "nonzero_ext",
  "object_store",
  "once_cell",
@@ -8559,10 +9091,41 @@ dependencies = [
  "serde",
  "serde_with",
  "serde_yaml 0.8.26",
- "sui-keys",
- "sui-protocol-config",
- "sui-rpc-api",
- "sui-types",
+ "sui-keys 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "sui-protocol-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "sui-rpc-api 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "tracing",
+]
+
+[[package]]
+name = "sui-config"
+version = "0.0.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "anemo",
+ "anyhow",
+ "bcs",
+ "clap",
+ "consensus-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "csv",
+ "dirs 4.0.0",
+ "fastcrypto 0.1.8",
+ "move-vm-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "mysten-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "nonzero_ext",
+ "object_store",
+ "once_cell",
+ "prometheus",
+ "rand 0.8.5",
+ "reqwest",
+ "serde",
+ "serde_with",
+ "serde_yaml 0.8.26",
+ "sui-keys 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-protocol-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-rpc-api 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
  "tracing",
 ]
 
@@ -8570,6 +9133,14 @@ dependencies = [
 name = "sui-enum-compat-util"
 version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
+dependencies = [
+ "serde_yaml 0.8.26",
+]
+
+[[package]]
+name = "sui-enum-compat-util"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -8595,6 +9166,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "sui-http"
+version = "0.0.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "bytes",
+ "http 1.3.1",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower 0.4.13",
+ "tracing",
+]
+
+[[package]]
 name = "sui-json"
 version = "0.0.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
@@ -8602,13 +9193,30 @@ dependencies = [
  "anyhow",
  "bcs",
  "fastcrypto 0.1.8",
- "move-binary-format",
- "move-bytecode-utils",
- "move-core-types",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-bytecode-utils 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
  "schemars",
  "serde",
  "serde_json",
- "sui-types",
+ "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+]
+
+[[package]]
+name = "sui-json"
+version = "0.0.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "anyhow",
+ "bcs",
+ "fastcrypto 0.1.8",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-bytecode-utils 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
 ]
 
 [[package]]
@@ -8619,14 +9227,34 @@ dependencies = [
  "anyhow",
  "fastcrypto 0.1.8",
  "jsonrpsee",
- "mysten-metrics",
+ "mysten-metrics 0.7.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
  "once_cell",
  "prometheus",
- "sui-json",
- "sui-json-rpc-types",
- "sui-open-rpc",
- "sui-open-rpc-macros",
- "sui-types",
+ "sui-json 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "sui-json-rpc-types 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "sui-open-rpc 1.45.2",
+ "sui-open-rpc-macros 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "tap",
+ "tracing",
+]
+
+[[package]]
+name = "sui-json-rpc-api"
+version = "0.0.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "anyhow",
+ "fastcrypto 0.1.8",
+ "jsonrpsee",
+ "mysten-metrics 0.7.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "once_cell",
+ "prometheus",
+ "sui-json 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-json-rpc-types 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-open-rpc 1.46.2",
+ "sui-open-rpc-macros 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
  "tap",
  "tracing",
 ]
@@ -8643,22 +9271,54 @@ dependencies = [
  "fastcrypto 0.1.8",
  "itertools 0.13.0",
  "json_to_table",
- "move-binary-format",
- "move-bytecode-utils",
- "move-core-types",
- "move-disassembler",
- "move-ir-types",
- "mysten-metrics",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-bytecode-utils 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-disassembler 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-ir-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "mysten-metrics 0.7.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
  "schemars",
  "serde",
  "serde_json",
  "serde_with",
- "sui-enum-compat-util",
- "sui-json",
- "sui-macros",
- "sui-package-resolver",
- "sui-protocol-config",
- "sui-types",
+ "sui-enum-compat-util 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "sui-json 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "sui-macros 0.7.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "sui-package-resolver 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "sui-protocol-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "tabled",
+ "tracing",
+]
+
+[[package]]
+name = "sui-json-rpc-types"
+version = "0.0.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "anyhow",
+ "bcs",
+ "colored 2.2.0",
+ "enum_dispatch",
+ "fastcrypto 0.1.8",
+ "itertools 0.13.0",
+ "json_to_table",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-bytecode-utils 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-disassembler 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-ir-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "mysten-metrics 0.7.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sui-enum-compat-util 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-json 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-macros 0.7.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-package-resolver 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-protocol-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
  "tabled",
  "tracing",
 ]
@@ -8675,10 +9335,29 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "shared-crypto",
+ "shared-crypto 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
  "signature 1.6.4",
  "slip10_ed25519",
- "sui-types",
+ "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "tiny-bip39",
+]
+
+[[package]]
+name = "sui-keys"
+version = "0.0.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "anyhow",
+ "bip32",
+ "fastcrypto 0.1.8",
+ "rand 0.8.5",
+ "regex",
+ "serde",
+ "serde_json",
+ "shared-crypto 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "signature 1.6.4",
+ "slip10_ed25519",
+ "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
  "tiny-bip39",
 ]
 
@@ -8689,7 +9368,18 @@ source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96b
 dependencies = [
  "futures",
  "once_cell",
- "sui-proc-macros",
+ "sui-proc-macros 0.7.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "tracing",
+]
+
+[[package]]
+name = "sui-macros"
+version = "0.7.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "futures",
+ "once_cell",
+ "sui-proc-macros 0.7.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
  "tracing",
 ]
 
@@ -8697,6 +9387,18 @@ dependencies = [
 name = "sui-open-rpc"
 version = "1.45.2"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
+dependencies = [
+ "bcs",
+ "schemars",
+ "serde",
+ "serde_json",
+ "versions",
+]
+
+[[package]]
+name = "sui-open-rpc"
+version = "1.46.2"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
  "bcs",
  "schemars",
@@ -8719,6 +9421,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sui-open-rpc-macros"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "derive-syn-parse",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "unescape",
+]
+
+[[package]]
 name = "sui-package-resolver"
 version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
@@ -8727,12 +9442,31 @@ dependencies = [
  "bcs",
  "eyre",
  "lru 0.10.1",
- "move-binary-format",
- "move-command-line-common",
- "move-core-types",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
  "serde",
- "sui-rpc-api",
- "sui-types",
+ "sui-rpc-api 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
+name = "sui-package-resolver"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "async-trait",
+ "bcs",
+ "eyre",
+ "lru 0.10.1",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-command-line-common 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "serde",
+ "sui-rpc-api 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -8745,7 +9479,19 @@ dependencies = [
  "msim-macros",
  "proc-macro2",
  "quote",
- "sui-enum-compat-util",
+ "sui-enum-compat-util 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "sui-proc-macros"
+version = "0.7.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "msim-macros",
+ "proc-macro2",
+ "quote",
+ "sui-enum-compat-util 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
  "syn 2.0.100",
 ]
 
@@ -8756,12 +9502,28 @@ source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96b
 dependencies = [
  "clap",
  "insta",
- "move-vm-config",
+ "move-vm-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
  "schemars",
  "serde",
  "serde-env",
  "serde_with",
- "sui-protocol-config-macros",
+ "sui-protocol-config-macros 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "tracing",
+]
+
+[[package]]
+name = "sui-protocol-config"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "clap",
+ "insta",
+ "move-vm-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "schemars",
+ "serde",
+ "serde-env",
+ "serde_with",
+ "sui-protocol-config-macros 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
  "tracing",
 ]
 
@@ -8769,6 +9531,16 @@ dependencies = [
 name = "sui-protocol-config-macros"
 version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "sui-protocol-config-macros"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8791,9 +9563,9 @@ dependencies = [
  "http 1.3.1",
  "itertools 0.13.0",
  "mime",
- "move-binary-format",
- "move-core-types",
- "mysten-network",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "mysten-network 0.2.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
  "prometheus",
  "prost",
  "prost-types",
@@ -8802,10 +9574,53 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "sui-protocol-config",
+ "sui-protocol-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
  "sui-sdk-types 0.0.2 (git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5e11579031793f086178332219f5847ec94da0c4)",
  "sui-transaction-builder 0.1.0",
- "sui-types",
+ "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "tap",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-health",
+ "tonic-reflection",
+ "tower 0.4.13",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "sui-rpc-api"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.21.7",
+ "bcs",
+ "bytes",
+ "fastcrypto 0.1.8",
+ "http 1.3.1",
+ "itertools 0.13.0",
+ "mime",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "mysten-network 0.2.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "prometheus",
+ "prost",
+ "prost-types",
+ "rand 0.8.5",
+ "roaring",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sui-protocol-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-sdk-types 0.0.4",
+ "sui-transaction-builder 0.0.4",
+ "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
  "tap",
  "thiserror 1.0.69",
  "tokio",
@@ -8833,19 +9648,52 @@ dependencies = [
  "futures",
  "futures-core",
  "jsonrpsee",
- "move-core-types",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
  "reqwest",
  "serde",
  "serde_json",
  "serde_with",
- "shared-crypto",
- "sui-config",
- "sui-json",
- "sui-json-rpc-api",
- "sui-json-rpc-types",
- "sui-keys",
- "sui-transaction-builder 0.0.0",
- "sui-types",
+ "shared-crypto 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "sui-config 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "sui-json 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "sui-json-rpc-api 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "sui-json-rpc-types 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "sui-keys 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "sui-transaction-builder 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "sui-sdk"
+version = "1.46.2"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.21.7",
+ "bcs",
+ "clap",
+ "colored 2.2.0",
+ "fastcrypto 0.1.8",
+ "futures",
+ "futures-core",
+ "jsonrpsee",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "shared-crypto 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-config 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-json 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-json-rpc-api 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-json-rpc-types 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-keys 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-transaction-builder 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -8890,9 +9738,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "sui-sdk-types"
+version = "0.0.4"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=83ff809bc11cbabda21b60130e1f5420170548bf#83ff809bc11cbabda21b60130e1f5420170548bf"
+dependencies = [
+ "base64ct",
+ "bcs",
+ "blake2",
+ "bnum",
+ "bs58 0.5.1",
+ "hex",
+ "roaring",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with",
+ "winnow 0.7.4",
+]
+
+[[package]]
 name = "sui-tls"
 version = "0.0.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
+dependencies = [
+ "anyhow",
+ "arc-swap",
+ "axum",
+ "axum-server",
+ "ed25519",
+ "fastcrypto 0.1.8",
+ "pkcs8 0.10.2",
+ "rcgen",
+ "reqwest",
+ "rustls",
+ "rustls-webpki 0.103.0",
+ "tokio",
+ "tokio-rustls",
+ "tower-layer",
+ "x509-parser 0.17.0",
+]
+
+[[package]]
+name = "sui-tls"
+version = "0.0.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8920,12 +9809,43 @@ dependencies = [
  "async-trait",
  "bcs",
  "futures",
- "move-binary-format",
- "move-core-types",
- "sui-json",
- "sui-json-rpc-types",
- "sui-protocol-config",
- "sui-types",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "sui-json 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "sui-json-rpc-types 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "sui-protocol-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+]
+
+[[package]]
+name = "sui-transaction-builder"
+version = "0.0.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bcs",
+ "futures",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-json 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-json-rpc-types 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-protocol-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-types 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+]
+
+[[package]]
+name = "sui-transaction-builder"
+version = "0.0.4"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=83ff809bc11cbabda21b60130e1f5420170548bf#83ff809bc11cbabda21b60130e1f5420170548bf"
+dependencies = [
+ "base64ct",
+ "bcs",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sui-sdk-types 0.0.4",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -8956,7 +9876,7 @@ dependencies = [
  "byteorder",
  "chrono",
  "ciborium",
- "consensus-config",
+ "consensus-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
  "derive_more 1.0.0",
  "enum_dispatch",
  "eyre",
@@ -8967,13 +9887,13 @@ dependencies = [
  "indexmap 2.8.0",
  "itertools 0.13.0",
  "lru 0.10.1",
- "move-binary-format",
- "move-bytecode-utils",
- "move-core-types",
- "move-vm-profiler",
- "move-vm-test-utils",
- "mysten-metrics",
- "mysten-network",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-bytecode-utils 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-vm-profiler 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "move-vm-test-utils 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "mysten-metrics 0.7.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "mysten-network 0.2.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
  "nonempty",
  "num-bigint 0.4.6",
  "num-traits",
@@ -8993,20 +9913,88 @@ dependencies = [
  "serde-name",
  "serde_json",
  "serde_with",
- "shared-crypto",
+ "shared-crypto 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
  "signature 1.6.4",
  "static_assertions",
  "strum 0.24.1",
  "strum_macros 0.24.3",
- "sui-enum-compat-util",
- "sui-macros",
- "sui-protocol-config",
+ "sui-enum-compat-util 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "sui-macros 0.7.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "sui-protocol-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
  "sui-sdk-types 0.0.2 (git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5e11579031793f086178332219f5847ec94da0c4)",
  "tap",
  "thiserror 1.0.69",
  "tonic",
  "tracing",
- "typed-store-error",
+ "typed-store-error 0.4.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2)",
+ "x509-parser 0.17.0",
+]
+
+[[package]]
+name = "sui-types"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
+dependencies = [
+ "anemo",
+ "anyhow",
+ "async-trait",
+ "bcs",
+ "better_any",
+ "bincode",
+ "byteorder",
+ "chrono",
+ "ciborium",
+ "consensus-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "derive_more 1.0.0",
+ "enum_dispatch",
+ "eyre",
+ "fastcrypto 0.1.8",
+ "fastcrypto-tbls",
+ "fastcrypto-zkp",
+ "im",
+ "indexmap 2.8.0",
+ "itertools 0.13.0",
+ "lru 0.10.1",
+ "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-bytecode-utils 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-vm-profiler 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "move-vm-test-utils 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "mysten-metrics 0.7.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "mysten-network 0.2.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "nonempty",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "num_enum",
+ "once_cell",
+ "p384",
+ "parking_lot",
+ "passkey-types",
+ "prometheus",
+ "proptest",
+ "proptest-derive",
+ "rand 0.8.5",
+ "roaring",
+ "rustls-pemfile",
+ "schemars",
+ "serde",
+ "serde-name",
+ "serde_json",
+ "serde_with",
+ "shared-crypto 0.0.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "signature 1.6.4",
+ "static_assertions",
+ "strum 0.27.1",
+ "strum_macros 0.27.1",
+ "sui-enum-compat-util 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-macros 0.7.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-protocol-config 0.1.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
+ "sui-sdk-types 0.0.4",
+ "tap",
+ "thiserror 1.0.69",
+ "tonic",
+ "tracing",
+ "typed-store-error 0.4.0 (git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2)",
  "x509-parser 0.17.0",
 ]
 
@@ -9793,6 +10781,15 @@ dependencies = [
 name = "typed-store-error"
 version = "0.4.0"
 source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.45.2#88ba4e08e96ba1ab965c11ce1a915331dd3ed68d"
+dependencies = [
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "typed-store-error"
+version = "0.4.0"
+source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.46.2#43e8aad17f0d1f5481b529201b9c320a6bbb382e"
 dependencies = [
  "serde",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,12 @@ version = "0.1.0"
 anyhow                = "1.0.91"
 async-trait           = "0.1.88"
 atoma-auth            = { path = "./atoma-auth" }
-atoma-p2p             = { git = "https://github.com/atoma-network/atoma-node.git", package = "atoma-p2p", branch = "main" }
+atoma-p2p             = { git = "https://github.com/atoma-network/atoma-node.git", package = "atoma-p2p", branch = "openrouter-integration" }
 atoma-proxy-service   = { path = "./atoma-proxy-service" }
 atoma-state           = { path = "./atoma-state" }
-atoma-sui             = { git = "https://github.com/atoma-network/atoma-node.git", package = "atoma-sui", branch = "main" }
-atoma-utils           = { git = "https://github.com/atoma-network/atoma-node.git", package = "atoma-utils", branch = "main" }
-axum                  = "0.7.7"
+atoma-sui             = { git = "https://github.com/atoma-network/atoma-node.git", package = "atoma-sui", branch = "openrouter-integration" }
+atoma-utils           = { git = "https://github.com/atoma-network/atoma-node.git", package = "atoma-utils", branch = "openrouter-integration" }
+axum                  = "0.8.3"
 base64                = "0.22.1"
 bcs                   = "0.1.6"
 blake2                = "0.10.6"
@@ -70,8 +70,8 @@ tracing-loki          = "0.2.6"
 tracing-opentelemetry = "0.28.0"
 tracing-subscriber    = "0.3.18"
 url                   = "2.5.4"
-utoipa                = "5.2.0"
-utoipa-swagger-ui     = "8.0.3"
+utoipa                = "5.3.1"
+utoipa-swagger-ui     = "9.0.1"
 uuid                  = "1.15.1"
 x25519-dalek          = "2.0.1"
 zeroize               = "1.8.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,10 +52,10 @@ serde                 = "1.0.214"
 serde_json            = "1.0.140"
 serde_yaml            = "0.9.34"
 serial_test           = "3.1.1"
-shared-crypto         = { git = "https://github.com/mystenlabs/sui", package = "shared-crypto", tag = "testnet-v1.45.2" }
+shared-crypto         = { git = "https://github.com/mystenlabs/sui", package = "shared-crypto", tag = "testnet-v1.46.2" }
 sqlx                  = { version = "0.8.2", features = [ "postgres", "runtime-tokio-native-tls" ] }
-sui-keys              = { git = "https://github.com/mystenlabs/sui", package = "sui-keys", tag = "testnet-v1.45.2" }
-sui-sdk               = { git = "https://github.com/mystenlabs/sui", package = "sui-sdk", tag = "testnet-v1.45.2" }
+sui-keys              = { git = "https://github.com/mystenlabs/sui", package = "sui-keys", tag = "testnet-v1.46.2" }
+sui-sdk               = { git = "https://github.com/mystenlabs/sui", package = "sui-sdk", tag = "testnet-v1.46.2" }
 sui-sdk-types         = "0.0.2"
 thiserror             = "2.0.12"
 tokenizers            = "0.21.0"

--- a/atoma-proxy-service/Cargo.toml
+++ b/atoma-proxy-service/Cargo.toml
@@ -25,7 +25,7 @@ tower-http                   = { workspace = true, features = [ "cors" ] }
 tracing.workspace            = true
 tracing-subscriber.workspace = true
 utoipa                       = { workspace = true, features = [ "axum_extras" ] }
-utoipa-swagger-ui            = { workspace = true }
+utoipa-swagger-ui            = { workspace = true, features = [ "axum" ] }
 
 [features]
 google-oauth = [ "atoma-auth/google-oauth" ]

--- a/atoma-proxy-service/src/handlers/auth.rs
+++ b/atoma-proxy-service/src/handlers/auth.rs
@@ -691,7 +691,6 @@ pub struct GetZkSalt;
     )
 )]
 #[instrument(level = "info", skip_all)]
-#[axum::debug_handler]
 pub async fn get_zk_salt(
     State(proxy_service_state): State<ProxyServiceState>,
     headers: HeaderMap,

--- a/atoma-proxy-service/src/handlers/stats.rs
+++ b/atoma-proxy-service/src/handlers/stats.rs
@@ -405,7 +405,6 @@ pub struct GetGraphData;
         (status = INTERNAL_SERVER_ERROR, description = "Failed to get graph data")
     )
 )]
-#[axum::debug_handler]
 #[instrument(level = "trace", skip_all)]
 async fn get_graph_data(
     State(proxy_service_state): State<ProxyServiceState>,


### PR DESCRIPTION
Bumps: 
 - sui version to 1.46.2
 - utoipa to 5.3.1
 - utoipa-swagger-ui to 9.0.1
 - axum to 0.8.3