### PR TITLE
feat: add stats

### DIFF
--- a/atoma-proxy-service/docs/openapi.yml
+++ b/atoma-proxy-service/docs/openapi.yml
@@ -613,32 +613,29 @@ paths:
               schema: {}
         '500':
           description: Failed to get graphs
-  /get_graph_data:
-    post:
+  /get_stats:
+    get:
       tags:
       - Stats
-      summary: Get graph data.
-      description: |+
+      summary: Get stats.
+      description: |-
         # Arguments
 
         * `proxy_service_state` - The shared state containing the state manager
-        * `query` - The query for grafana
-
         # Returns
 
-        * `Result<Json<Value>>` - A JSON response containing the graph data
-          - `Ok(Json<Value>)` - Successfully retrieved graph data
-          - `Err(StatusCode::INTERNAL_SERVER_ERROR)` - Failed to retrieve graph data from state manager
-
-      operationId: get_graph_data
+        * `Result<Json<Value>>` - A JSON response containing a list of graphs
+          - `Ok(Json<Value>)` - Successfully retrieved graphs
+          - `Err(StatusCode::INTERNAL_SERVER_ERROR)` - Failed to retrieve graphs from state manager
+      operationId: get_stats
       responses:
         '200':
-          description: Retrieves graph data
+          description: Retrieves all graphs
           content:
             application/json:
               schema: {}
         '500':
-          description: Failed to get graph data
+          description: Failed to get graphs
   /google_oauth:
     post:
       tags:

--- a/atoma-proxy-service/src/components/grafana.rs
+++ b/atoma-proxy-service/src/components/grafana.rs
@@ -2,9 +2,9 @@ use reqwest::{Client, Response, StatusCode};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
-use tracing::instrument;
+use tracing::{error, instrument};
 
-use crate::handlers::stats::PanelResponse;
+use crate::handlers::stats::{DashboardResponse, PanelResponse};
 
 /// The list of dashboards uids returned from grafana
 #[derive(Deserialize)]
@@ -26,7 +26,7 @@ struct Time {
 #[derive(Deserialize, Serialize)]
 struct Panel {
     /// The targets, that's actually the queries to run
-    targets: Value,
+    targets: Vec<Value>,
     /// The title of the panel
     title: String,
     /// The panel description
@@ -35,7 +35,7 @@ struct Panel {
     #[serde(rename = "fieldConfig")]
     field_config: Value,
     /// Interval set in grafana
-    interval: Option<String>,
+    interval: Value,
     /// Type of the graph
     #[serde(rename = "type")]
     graph_type: String,
@@ -70,7 +70,7 @@ impl Dashboard {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Query {
     /// The queries to run (left as a json that was returned from grafana)
-    queries: Value,
+    pub queries: Vec<Value>,
     /// Time range to query, in the format like "now-1w"
     from: String,
     /// Time range to query, usually it's just "now"
@@ -91,11 +91,13 @@ impl From<Dashboard> for Vec<PanelResponse> {
                 field_config: panel.field_config,
                 interval: panel.interval,
                 graph_type: panel.graph_type,
+                data: Value::Null,
                 query: Query {
                     queries: panel.targets,
                     from: from.clone(),
                     to: to.clone(),
                 },
+                from: from.clone(),
             })
             .collect()
     }
@@ -110,8 +112,6 @@ pub struct Grafana {
     url: String,
     /// The API token to use for authentication
     api_token: String,
-    /// The tag to use to filter dashboards
-    dashboard_tag: String,
     /// The reqwest client to use for requests
     client: Client,
 }
@@ -125,11 +125,10 @@ impl Grafana {
     /// * `api_token` - The API token to use for authentication
     /// * `dashboard_tag` - The tag to use to filter dashboards
     #[must_use]
-    pub fn new(url: String, api_token: String, dashboard_tag: String) -> Self {
+    pub fn new(url: String, api_token: String) -> Self {
         Self {
             url,
             api_token,
-            dashboard_tag,
             client: Client::new(),
         }
     }
@@ -140,14 +139,15 @@ impl Grafana {
             .header("Authorization", format!("Bearer {}", self.api_token))
             .header("Content-Type", "application/json")
     }
+
     /// Get the UIDs of all dashboards with the specified tag
     ///
     /// # Returns
     ///
     /// A vector of dashboard UIDs
     #[instrument(level = "info", skip_all)]
-    pub async fn get_dashboard_uids(&self) -> Result<Vec<String>, GrafanaError> {
-        let request_url = format!("{}/api/search?tag={}", self.url, self.dashboard_tag);
+    async fn get_dashboard_uids(&self, tag: String) -> Result<Vec<String>, GrafanaError> {
+        let request_url = format!("{}/api/search?tag={}", self.url, tag);
         let response = self
             .prepare_request(self.client.get(&request_url))
             .send()
@@ -160,6 +160,39 @@ impl Grafana {
             .collect())
     }
 
+    /// Get all dashboards with the specified tag
+    ///
+    /// # Arguments
+    ///
+    /// * `tag` - The tag to use to filter dashboards
+    pub async fn get_dashboards(
+        &self,
+        tag: String,
+    ) -> Result<Vec<DashboardResponse>, GrafanaError> {
+        let uids = self.get_dashboard_uids(tag).await?;
+        let mut results = Vec::new();
+        for uid in uids {
+            let dashboard = self.get_dashboard(uid).await?;
+            let dashboard_title = dashboard.title();
+            let mut panels: Vec<PanelResponse> = dashboard.into();
+            for panel in &mut panels {
+                for query in panel.query.queries.iter_mut() {
+                    query
+                        .as_object_mut()
+                        .unwrap()
+                        .insert("interval".to_string(), panel.interval.clone());
+                }
+                let data = self.get_query_data(&panel.query).await?;
+                panel.data = data;
+            }
+            results.push(DashboardResponse {
+                title: dashboard_title,
+                panels,
+            });
+        }
+        Ok(results)
+    }
+
     /// Get a dashboard by its UID
     ///
     /// # Arguments
@@ -170,7 +203,7 @@ impl Grafana {
     ///
     /// The dashboard with the specified UID
     #[instrument(level = "info", skip(self))]
-    pub async fn get_dashboard(&self, dashboard_uid: String) -> Result<Dashboard, GrafanaError> {
+    async fn get_dashboard(&self, dashboard_uid: String) -> Result<Dashboard, GrafanaError> {
         let request_url = format!("{}/api/dashboards/uid/{}", self.url, dashboard_uid);
         let response = self
             .prepare_request(self.client.get(&request_url))
@@ -190,12 +223,12 @@ impl Grafana {
     ///
     /// The data for the query
     #[instrument(level = "info", skip_all)]
-    pub async fn get_query_data(&self, query: Query) -> Result<Value, GrafanaError> {
+    pub async fn get_query_data(&self, query: &Query) -> Result<Value, GrafanaError> {
         let request_url = format!("{}/api/ds/query", self.url);
 
         let response = self
             .prepare_request(self.client.post(&request_url))
-            .json(&query)
+            .json(query)
             .send()
             .await?;
 

--- a/atoma-proxy-service/src/components/openapi.rs
+++ b/atoma-proxy-service/src/components/openapi.rs
@@ -23,9 +23,9 @@ use crate::{
             GET_CURRENT_STACKS_PATH,
         },
         stats::{
-            GetComputeUnitsProcessed, GetGraphData, GetGraphs, GetLatency, GetNodeDistribution,
-            GetStatsStacks, COMPUTE_UNITS_PROCESSED_PATH, GET_GRAPHS_PATH, GET_GRAPH_DATA_PATH,
-            GET_NODES_DISTRIBUTION_PATH, GET_STATS_STACKS_PATH, LATENCY_PATH,
+            GetComputeUnitsProcessed, GetGraphs, GetLatency, GetNodeDistribution, GetStats,
+            GetStatsStacks, COMPUTE_UNITS_PROCESSED_PATH, GET_GRAPHS_PATH,
+            GET_NODES_DISTRIBUTION_PATH, GET_STATS_PATH, GET_STATS_STACKS_PATH, LATENCY_PATH,
         },
         subscriptions::{GetAllSubscriptionsOpenApi, SUBSCRIPTIONS_PATH},
         tasks::{GetAllTasksOpenApi, TASKS_PATH},
@@ -60,7 +60,7 @@ pub fn openapi_router() -> Router {
             (path = SUBSCRIPTIONS_PATH, api = GetAllSubscriptionsOpenApi, tags = ["Subscriptions"]),
             (path = GET_NODES_DISTRIBUTION_PATH, api = GetNodeDistribution, tags = ["Stats"]),
             (path = GET_GRAPHS_PATH, api = GetGraphs, tags = ["Stats"]),
-            (path = GET_GRAPH_DATA_PATH, api = GetGraphData, tags = ["Stats"]),
+            (path = GET_STATS_PATH, api = GetStats, tags = ["Stats"]),
         ),
         tags(
             (name = "Health", description = "Health check endpoints"),

--- a/atoma-proxy-service/src/config.rs
+++ b/atoma-proxy-service/src/config.rs
@@ -17,8 +17,11 @@ pub struct AtomaProxyServiceConfig {
     /// Grafana api token (read only access is sufficient)
     pub grafana_api_token: String,
 
-    /// Only dashboards tagged with this tag will be proxied
+    /// Only dashboards tagged with this tag will be proxied as graphs
     pub grafana_dashboard_tag: String,
+
+    /// Only dashboards tagged with this tag will be proxied as stats
+    pub grafana_stats_tag: String,
 }
 
 impl AtomaProxyServiceConfig {

--- a/atoma-proxy-service/src/proxy_service.rs
+++ b/atoma-proxy-service/src/proxy_service.rs
@@ -66,6 +66,12 @@ pub struct ProxyServiceState {
 
     /// Grafana client for fetching dashboards.
     pub grafana: Grafana,
+
+    /// The tag to use to filter dashboards for graphs
+    pub dashboard_tag: String,
+
+    /// The tag to use to filter dashboards for stats
+    pub stats_tag: String,
 }
 
 /// Starts and runs the Atoma proxy service service, handling HTTP requests and graceful shutdown.

--- a/atoma-proxy/src/main.rs
+++ b/atoma-proxy/src/main.rs
@@ -179,7 +179,6 @@ async fn main() -> Result<()> {
     let grafana = Grafana::new(
         config.proxy_service.grafana_url,
         config.proxy_service.grafana_api_token,
-        config.proxy_service.grafana_dashboard_tag,
     );
 
     let proxy_service_state = ProxyServiceState {
@@ -187,6 +186,8 @@ async fn main() -> Result<()> {
         auth,
         models_with_modalities,
         grafana,
+        dashboard_tag: config.proxy_service.grafana_dashboard_tag,
+        stats_tag: config.proxy_service.grafana_stats_tag,
     };
 
     let proxy_service_handle = spawn_with_shutdown(

--- a/config.example.toml
+++ b/config.example.toml
@@ -44,7 +44,8 @@ service_bind_address = "0.0.0.0:8080" # HTTP service binding address and port (m
 
 [atoma_proxy_service]
 grafana_api_token     = ""             # Grafana API token (read-only permissions required)
-grafana_dashboard_tag = ""             # Tag to filter which Grafana dashboards to expose
+grafana_dashboard_tag = ""             # Tag to filter which Grafana dashboards to expose as graphs
+grafana_stats_tag     = ""             # Tag to filter which Grafana dashboards to expose as stats
 grafana_url           = ""             # Grafana instance URL for metrics visualization
 service_bind_address  = "0.0.0.0:8081" # Proxy service binding address and port (must match docker-compose.yml)
 


### PR DESCRIPTION
Add stats endpoint.
Stats will pull all dashboards that are tagged as "stats". Only Stat charts should be marked as this.
The name has to match the name in the dashboard UI. e.g. Performance
This way we can pull not just graphs but also stats from grafana/prometheus.

Also merge get_graphs into single endpoint. This way we run only queries that are defined in grafana.