### PR TITLE
chore: track cancelled streams

### DIFF
--- a/atoma-proxy/src/server/handlers/chat_completions.rs
+++ b/atoma-proxy/src/server/handlers/chat_completions.rs
@@ -175,7 +175,6 @@ pub async fn chat_completions_create(
 ) -> Result<Response<Body>> {
     let endpoint = metadata.endpoint.clone();
     tokio::spawn(async move {
-        // TODO: We should allow cancelling the request if the client disconnects
         let is_streaming = payload
             .get(STREAM)
             .and_then(serde_json::Value::as_bool)
@@ -1045,7 +1044,7 @@ async fn handle_streaming_response(
             start,
             user_id,
             model_name.clone(),
-            endpoint.clone(),
+            endpoint,
         );
         loop {
             tokio::select! {
@@ -1091,6 +1090,7 @@ async fn handle_streaming_response(
                             e
                         );
                     }
+                    // We continue the loop, to allow the streamer to finish with updated usage from the node
                 }
             }
         }

--- a/atoma-proxy/src/server/handlers/chat_completions.rs
+++ b/atoma-proxy/src/server/handlers/chat_completions.rs
@@ -1091,11 +1091,6 @@ async fn handle_streaming_response(
                             e
                         );
                     }
-                    // Return a 400 status code when the stream is cancelled
-                    return Err(AtomaProxyError::RequestError {
-                        message: "Stream cancelled by user".to_string(),
-                        endpoint,
-                    });
                 }
             }
         }
@@ -1103,7 +1098,6 @@ async fn handle_streaming_response(
             target = "atoma-service-chat-completions",
             "Streamer finished for request id: {request_id}"
         );
-        Ok(())
     });
 
     // Create the SSE stream

--- a/atoma-proxy/src/server/handlers/metrics.rs
+++ b/atoma-proxy/src/server/handlers/metrics.rs
@@ -110,6 +110,24 @@ pub static CHAT_COMPLETIONS_STREAMING_LATENCY_METRICS: LazyLock<Histogram<f64>> 
             .build()
     });
 
+/// Counter metric that tracks the total number of intentionally cancelled chat completion streaming requests.
+///
+/// # Metric Details
+/// - Name: `atoma_intentionally_cancelled_chat_completion_streaming_requests`
+/// - Type: Counter
+/// - Labels: `model`
+/// - Unit: requests (count)
+pub static INTENTIONALLY_CANCELLED_CHAT_COMPLETION_STREAMING_REQUESTS: LazyLock<Counter<u64>> =
+    LazyLock::new(|| {
+        GLOBAL_METER
+            .u64_counter("atoma_intentionally_cancelled_chat_completion_streaming_requests")
+            .with_description(
+                "The number of intentionally cancelled chat completion streaming requests",
+            )
+            .with_unit("requests")
+            .build()
+    });
+
 /// Histogram metric that tracks the latency of image generation requests.
 ///
 /// This metric measures the time taken to generate images, broken down by model type.


### PR DESCRIPTION
If a user intentionally cancells a stream, we should return the proper error message which indicates that it's a client error and not a fault of the service