### PR TITLE
fix: fiat/stack updates

### DIFF
--- a/atoma-proxy/src/server/handlers/chat_completions.rs
+++ b/atoma-proxy/src/server/handlers/chat_completions.rs
@@ -195,25 +195,22 @@ pub async fn chat_completions_create(
                 TOTAL_FAILED_CHAT_REQUESTS.add(1, &[KeyValue::new("model", model_label)]);
                 UNSUCCESSFUL_CHAT_COMPLETION_REQUESTS_PER_USER
                     .add(1, &[KeyValue::new("user_id", metadata.user_id)]);
-                match metadata.selected_stack_small_id {
-                    Some(stack_small_id) => {
-                        update_state_manager(
-                            &state.state_manager_sender,
-                            stack_small_id,
-                            metadata.max_total_num_compute_units as i64,
-                            0,
-                            &metadata.endpoint,
-                        )?;
-                    }
-                    None => {
-                        update_state_manager_fiat(
-                            &state.state_manager_sender,
-                            metadata.user_id,
-                            metadata.fiat_estimated_amount.unwrap_or_default(),
-                            0,
-                            &metadata.endpoint,
-                        )?;
-                    }
+                if let Some(stack_small_id) = metadata.selected_stack_small_id {
+                    update_state_manager(
+                        &state.state_manager_sender,
+                        stack_small_id,
+                        metadata.max_total_num_compute_units as i64,
+                        0,
+                        &metadata.endpoint,
+                    )?;
+                } else {
+                    update_state_manager_fiat(
+                        &state.state_manager_sender,
+                        metadata.user_id,
+                        metadata.fiat_estimated_amount.unwrap_or_default(),
+                        0,
+                        &metadata.endpoint,
+                    )?;
                 }
                 Err(e)
             }
@@ -641,25 +638,22 @@ pub async fn confidential_chat_completions_create(
                 UNSUCCESSFUL_CHAT_COMPLETION_REQUESTS_PER_USER
                     .add(1, &[KeyValue::new("user_id", metadata.user_id)]);
 
-                match metadata.selected_stack_small_id {
-                    Some(stack_small_id) => {
-                        update_state_manager(
-                            &state.state_manager_sender,
-                            stack_small_id,
-                            metadata.max_total_num_compute_units as i64,
-                            0,
-                            &metadata.endpoint,
-                        )?;
-                    }
-                    None => {
-                        update_state_manager_fiat(
-                            &state.state_manager_sender,
-                            metadata.user_id,
-                            metadata.fiat_estimated_amount.unwrap_or_default(),
-                            0,
-                            &metadata.endpoint,
-                        )?;
-                    }
+                if let Some(stack_small_id) = metadata.selected_stack_small_id {
+                    update_state_manager(
+                        &state.state_manager_sender,
+                        stack_small_id,
+                        metadata.max_total_num_compute_units as i64,
+                        0,
+                        &metadata.endpoint,
+                    )?;
+                } else {
+                    update_state_manager_fiat(
+                        &state.state_manager_sender,
+                        metadata.user_id,
+                        metadata.fiat_estimated_amount.unwrap_or_default(),
+                        0,
+                        &metadata.endpoint,
+                    )?;
                 }
                 Err(e)
             }

--- a/atoma-proxy/src/server/handlers/embeddings.rs
+++ b/atoma-proxy/src/server/handlers/embeddings.rs
@@ -198,6 +198,26 @@ pub async fn embeddings_create(
                 TOTAL_COMPLETED_REQUESTS.add(1, &[KeyValue::new("model", metadata.model_name)]);
                 SUCCESSFUL_TEXT_EMBEDDING_REQUESTS_PER_USER
                     .add(1, &[KeyValue::new("user_id", metadata.user_id)]);
+                match metadata.selected_stack_small_id {
+                    Some(stack_small_id) => {
+                        update_state_manager(
+                            &state.state_manager_sender,
+                            stack_small_id,
+                            num_input_compute_units as i64,
+                            num_input_compute_units as i64,
+                            &metadata.endpoint,
+                        )?;
+                    }
+                    None => {
+                        update_state_manager_fiat(
+                            &state.state_manager_sender,
+                            metadata.user_id,
+                            metadata.fiat_estimated_amount.unwrap_or_default(),
+                            metadata.fiat_estimated_amount.unwrap_or_default(),
+                            &metadata.endpoint,
+                        )?;
+                    }
+                }
                 Ok(Json(response).into_response())
             }
             Err(e) => {

--- a/atoma-proxy/src/server/handlers/image_generations.rs
+++ b/atoma-proxy/src/server/handlers/image_generations.rs
@@ -188,6 +188,26 @@ pub async fn image_generations_create(
         {
             Ok(response) => {
                 TOTAL_COMPLETED_REQUESTS.add(1, &[KeyValue::new("model", metadata.model_name)]);
+                match metadata.selected_stack_small_id {
+                    Some(stack_small_id) => {
+                        update_state_manager(
+                            &state.state_manager_sender,
+                            stack_small_id,
+                            metadata.max_total_num_compute_units as i64,
+                            metadata.max_total_num_compute_units as i64,
+                            &metadata.endpoint,
+                        )?;
+                    }
+                    None => {
+                        update_state_manager_fiat(
+                            &state.state_manager_sender,
+                            metadata.user_id,
+                            metadata.fiat_estimated_amount.unwrap_or_default(),
+                            metadata.fiat_estimated_amount.unwrap_or_default(),
+                            &metadata.endpoint,
+                        )?;
+                    }
+                }
                 Ok(response.into_response())
             }
             Err(e) => {


### PR DESCRIPTION
For image generations/embeddings we only locked but never actually marked it as used.
Calculate the num of request for fiat payments.