### PR TITLE
feat: add node exporter for storage usage observability

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -218,6 +218,24 @@ services:
       - atoma-network
     user: "0"
 
+  node-exporter:
+    image: prom/node-exporter:v1.7.0
+    container_name: node-exporter
+    restart: unless-stopped
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - "--path.procfs=/host/proc"
+      - "--path.rootfs=/rootfs"
+      - "--path.sysfs=/host/sys"
+      - "--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)"
+    ports:
+      - "9101:9100"
+    networks:
+      - atoma-network
+
 volumes:
   postgres-data:
   sui-config-volume:

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -16,3 +16,9 @@ scrape_configs:
     static_configs:
       - targets: ["localhost:8889"] # Local development scraping
 
+  - job_name: "node-exporter"
+    static_configs:
+      - targets: ["node-exporter:9100"]
+        labels:
+          instance: "node-exporter"
+    metrics_path: /metrics


### PR DESCRIPTION
This will help to give us observability over our disk usage and other OS metrics needed for alerts.


In this case I can monitor `node_filesystem_avail_bytes{mountpoint="/var/lib/docker"}`
<img width="1330" alt="Screenshot 2025-05-07 at 12 15 06 PM" src="https://github.com/user-attachments/assets/2801457c-6f59-45fd-8e60-d1b5c7835bcb" />


where we could have alerts such as 

```
(
  100 * (1 - node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"}) > 85
  and
  rate(node_disk_read_bytes_total[5m]) > 0
)
```

when our disk usage exceeds 85% for instance