### PR TITLE
fix: optimize total hash storage

### DIFF
--- a/atoma-proxy/src/server/handlers/chat_completions.rs
+++ b/atoma-proxy/src/server/handlers/chat_completions.rs
@@ -14,7 +14,6 @@ use axum::http::HeaderValue;
 use axum::response::{IntoResponse, Response, Sse};
 use axum::Extension;
 use axum::{extract::State, http::HeaderMap, Json};
-use base64::engine::{general_purpose::STANDARD, Engine};
 use futures::StreamExt;
 use openai_api::message::Role;
 use openai_api::tools::ToolFunction;
@@ -54,10 +53,7 @@ use super::metrics::{
     UNSUCCESSFUL_CHAT_COMPLETION_REQUESTS_PER_USER,
 };
 use super::request_model::{ComputeUnitsEstimate, RequestModel};
-use super::{
-    handle_status_code_error, update_state_manager, verify_response_hash_and_signature,
-    RESPONSE_HASH_KEY,
-};
+use super::{handle_status_code_error, update_state_manager, verify_response_hash_and_signature};
 use crate::server::{Result, DEFAULT_MAX_TOKENS, MAX_COMPLETION_TOKENS, MAX_TOKENS, MODEL};
 
 /// Path for the confidential chat completions endpoint.
@@ -864,36 +860,6 @@ async fn handle_non_streaming_response(
             endpoint: endpoint.to_string(),
         })?;
 
-    // NOTE: It is not very secure to rely on the node's computed response hash,
-    // if the node is not running in a TEE, but for now it suffices
-    let total_hash = response
-        .get(RESPONSE_HASH_KEY)
-        .and_then(|hash| hash.as_str())
-        .map(|hash| STANDARD.decode(hash).unwrap_or_default())
-        .unwrap_or_default()
-        .try_into()
-        .map_err(|e: Vec<u8>| AtomaProxyError::InternalError {
-            message: format!(
-                "Error converting response hash to array, received array of length {}",
-                e.len()
-            ),
-            client_message: None,
-            endpoint: endpoint.to_string(),
-        })?;
-
-    if let Some(stack_small_id) = selected_stack_small_id {
-        state
-            .state_manager_sender
-            .send(AtomaAtomaStateManagerEvent::UpdateStackTotalHash {
-                stack_small_id,
-                total_hash,
-            })
-            .map_err(|err| AtomaProxyError::InternalError {
-                message: format!("Error updating stack total hash: {err:?}"),
-                client_message: None,
-                endpoint: endpoint.to_string(),
-            })?;
-    }
     // NOTE: We need to update the stack num tokens, because the inference response might have produced
     // less tokens than estimated what we initially estimated, from the middleware.
     match selected_stack_small_id {

--- a/atoma-proxy/src/server/handlers/embeddings.rs
+++ b/atoma-proxy/src/server/handlers/embeddings.rs
@@ -8,7 +8,6 @@ use axum::{
     response::{IntoResponse, Response},
     Extension, Json,
 };
-use base64::engine::{general_purpose::STANDARD, Engine};
 use opentelemetry::KeyValue;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -35,7 +34,6 @@ use super::{
     },
     request_model::{ComputeUnitsEstimate, RequestModel},
     update_state_manager, update_state_manager_fiat, verify_response_hash_and_signature,
-    RESPONSE_HASH_KEY,
 };
 use crate::server::Result;
 
@@ -190,7 +188,6 @@ pub async fn embeddings_create(
             num_input_compute_units as i64,
             metadata.endpoint.clone(),
             metadata.model_name.clone(),
-            metadata.selected_stack_small_id,
         )
         .await
         {
@@ -304,7 +301,6 @@ pub async fn confidential_embeddings_create(
             num_input_compute_units as i64,
             metadata.endpoint.clone(),
             metadata.model_name.clone(),
-            metadata.selected_stack_small_id,
         )
         .await
         {
@@ -426,7 +422,6 @@ async fn handle_embeddings_response(
     num_input_compute_units: i64,
     endpoint: String,
     model_name: String,
-    stack_small_id: Option<i64>,
 ) -> Result<Value> {
     // Record the request in the total text embedding requests metric
     let model_label: String = model_name.clone();
@@ -495,37 +490,6 @@ async fn handle_embeddings_response(
             client_message: None,
             endpoint: endpoint.to_string(),
         })?;
-
-    // NOTE: It is not very secure to rely on the node's computed response hash,
-    // if the node is not running in a TEE, but for now it suffices
-    let total_hash = response
-        .get(RESPONSE_HASH_KEY)
-        .and_then(|hash| hash.as_str())
-        .map(|hash| STANDARD.decode(hash).unwrap_or_default())
-        .unwrap_or_default()
-        .try_into()
-        .map_err(|e: Vec<u8>| AtomaProxyError::InternalError {
-            message: format!(
-                "Error converting response hash to array, received array of length {}",
-                e.len()
-            ),
-            client_message: None,
-            endpoint: endpoint.to_string(),
-        })?;
-
-    if let Some(stack_small_id) = stack_small_id {
-        state
-            .state_manager_sender
-            .send(AtomaAtomaStateManagerEvent::UpdateStackTotalHash {
-                stack_small_id,
-                total_hash,
-            })
-            .map_err(|err| AtomaProxyError::InternalError {
-                message: format!("Error updating stack total hash: {err:?}"),
-                client_message: None,
-                endpoint: endpoint.to_string(),
-            })?;
-    }
 
     TEXT_EMBEDDINGS_LATENCY_METRICS.record(
         time.elapsed().as_secs_f64(),

--- a/atoma-proxy/src/server/handlers/image_generations.rs
+++ b/atoma-proxy/src/server/handlers/image_generations.rs
@@ -5,7 +5,6 @@ use axum::body::Body;
 use axum::response::{IntoResponse, Response};
 use axum::Extension;
 use axum::{extract::State, http::HeaderMap, Json};
-use base64::engine::{general_purpose::STANDARD, Engine};
 use opentelemetry::KeyValue;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -28,7 +27,7 @@ use super::request_model::ComputeUnitsEstimate;
 use super::{
     handle_status_code_error, update_state_manager_fiat, verify_response_hash_and_signature,
 };
-use super::{request_model::RequestModel, update_state_manager, RESPONSE_HASH_KEY};
+use super::{request_model::RequestModel, update_state_manager};
 use crate::server::{Result, MODEL};
 
 /// Path for the confidential image generations endpoint.
@@ -182,7 +181,6 @@ pub async fn image_generations_create(
             metadata.max_total_num_compute_units as i64,
             metadata.endpoint.clone(),
             metadata.model_name.clone(),
-            metadata.selected_stack_small_id,
         )
         .await
         {
@@ -291,7 +289,6 @@ pub async fn confidential_image_generations_create(
             metadata.max_total_num_compute_units as i64,
             metadata.endpoint.clone(),
             metadata.model_name.clone(),
-            metadata.selected_stack_small_id,
         )
         .await
         {
@@ -391,7 +388,6 @@ async fn handle_image_generation_response(
     total_tokens: i64,
     endpoint: String,
     model_name: String,
-    stack_small_id: Option<i64>,
 ) -> Result<Response<Body>> {
     // Record the request in the image generations num requests metric
     let model_label: String = model_name.clone();
@@ -450,35 +446,6 @@ async fn handle_image_generation_response(
             client_message: None,
             endpoint: endpoint.to_string(),
         })?;
-
-    let total_hash = response
-        .get(RESPONSE_HASH_KEY)
-        .and_then(|hash| hash.as_str())
-        .map(|hash| STANDARD.decode(hash).unwrap_or_default())
-        .unwrap_or_default()
-        .try_into()
-        .map_err(|e: Vec<u8>| AtomaProxyError::InternalError {
-            message: format!(
-                "Error converting response hash to array, received array of length {}",
-                e.len()
-            ),
-            client_message: None,
-            endpoint: endpoint.to_string(),
-        })?;
-
-    if let Some(stack_small_id) = stack_small_id {
-        state
-            .state_manager_sender
-            .send(AtomaAtomaStateManagerEvent::UpdateStackTotalHash {
-                stack_small_id,
-                total_hash,
-            })
-            .map_err(|err| AtomaProxyError::InternalError {
-                message: format!("Error updating stack total hash: {err:?}"),
-                client_message: None,
-                endpoint: endpoint.to_string(),
-            })?;
-    }
 
     IMAGE_GEN_LATENCY_METRICS.record(
         time.elapsed().as_secs_f64(),

--- a/atoma-proxy/src/server/streamer.rs
+++ b/atoma-proxy/src/server/streamer.rs
@@ -4,7 +4,6 @@
 use atoma_state::types::AtomaAtomaStateManagerEvent;
 use axum::body::Bytes;
 use axum::{response::sse::Event, Error};
-use base64::engine::{general_purpose::STANDARD, Engine};
 use flume::{RecvError, Sender};
 use futures::{FutureExt, Stream};
 use opentelemetry::KeyValue;
@@ -248,27 +247,6 @@ impl Streamer {
         );
         match self.stack_small_id {
             Some(stack_small_id) => {
-                if let Some(response_hash) = response_hash {
-                    let total_hash = response_hash
-                        .as_str()
-                        .map(|hash| STANDARD.decode(hash).unwrap_or_default())
-                        .unwrap_or_default()
-                        .try_into()
-                        .map_err(|e: Vec<u8>| {
-                            Error::new(format!(
-                            "Error converting response hash to array, received array of length {}",
-                            e.len()
-                        ))
-                        })?;
-                    self.state_manager_sender
-                        .send(AtomaAtomaStateManagerEvent::UpdateStackTotalHash {
-                            stack_small_id,
-                            total_hash,
-                        })
-                        .map_err(|err| {
-                            Error::new(format!("Error updating stack total hash: {err:?}"))
-                        })?;
-                }
                 if let Err(e) = update_state_manager(
                     &self.state_manager_sender,
                     stack_small_id,

--- a/atoma-state/src/handlers.rs
+++ b/atoma-state/src/handlers.rs
@@ -1015,21 +1015,6 @@ pub async fn handle_state_manager_event(
                 .update_stack_num_tokens(stack_small_id, estimated_total_tokens, total_tokens)
                 .await?;
         }
-        AtomaAtomaStateManagerEvent::UpdateStackTotalHash {
-            stack_small_id,
-            total_hash,
-        } => {
-            trace!(
-                target = "atoma-state-handlers",
-                event = "handle-state-manager-event",
-                "Updating stack total hash for stack with id: {}",
-                stack_small_id
-            );
-            state_manager
-                .state
-                .update_stack_total_hash(stack_small_id, total_hash)
-                .await?;
-        }
         AtomaAtomaStateManagerEvent::GetStacksForModel {
             model,
             free_compute_units,
@@ -1755,7 +1740,7 @@ pub mod remote_attestation_verification {
     type Result<T> = std::result::Result<T, AtomaStateRemoteAttestationError>;
 
     #[instrument(
-        level = "info", 
+        level = "info",
         skip_all,
         fields(
             device_type = device_type,

--- a/atoma-state/src/migrations/20250507153627_drop_total_hash.sql
+++ b/atoma-state/src/migrations/20250507153627_drop_total_hash.sql
@@ -1,0 +1,3 @@
+-- Drop total_hash column from stacks table
+ALTER TABLE
+	stacks DROP COLUMN total_hash;

--- a/atoma-state/src/state_manager.rs
+++ b/atoma-state/src/state_manager.rs
@@ -2033,7 +2033,7 @@ impl AtomaState {
     ) -> Result<()> {
         sqlx::query(
             "INSERT INTO stacks
-                (owner, stack_small_id, stack_id, task_small_id, selected_node_id, num_compute_units, price_per_one_million_compute_units, already_computed_units, locked_compute_units, in_settle_period, total_hash, num_total_messages, user_id, acquired_timestamp)
+                (owner, stack_small_id, stack_id, task_small_id, selected_node_id, num_compute_units, price_per_one_million_compute_units, already_computed_units, locked_compute_units, in_settle_period, num_total_messages, user_id, acquired_timestamp)
                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)",
         )
             .bind(stack.owner)
@@ -2046,7 +2046,6 @@ impl AtomaState {
             .bind(stack.already_computed_units)
             .bind(stack.locked_compute_units)
             .bind(stack.in_settle_period)
-            .bind(stack.total_hash)
             .bind(stack.num_total_messages)
             .bind(user_id)
             .bind(acquired_timestamp)
@@ -2342,165 +2341,6 @@ impl AtomaState {
         .await?;
         tx.commit().await?;
         Ok(())
-    }
-
-    /// Updates the total hash and increments the total number of messages for a stack.
-    ///
-    /// This method updates the `total_hash` field in the `stacks` table by appending a new hash
-    /// to the existing hash and increments the `num_total_messages` field by 1 for the specified `stack_small_id`.
-    ///
-    /// # Arguments
-    ///
-    /// * `stack_small_id` - The unique small identifier of the stack to update.
-    /// * `new_hash` - A 32-byte array representing the new hash to append to the existing total hash.
-    ///
-    /// # Returns
-    ///
-    /// - `Result<()>`: A result indicating success (Ok(())) or failure (Err(AtomaStateManagerError)).
-    ///
-    /// # Errors
-    ///
-    /// This function will return an error if:
-    /// - The database transaction fails to begin, execute, or commit.
-    /// - The specified stack is not found.
-    ///
-    /// # Example
-    ///
-    /// ```rust,ignore
-    /// use atoma_node::atoma_state::AtomaStateManager;
-    ///
-    /// async fn update_hash(state_manager: &AtomaStateManager) -> Result<(), AtomaStateManagerError> {
-    ///     let stack_small_id = 1;
-    ///     let new_hash = [0u8; 32]; // Example hash
-    ///
-    ///     state_manager.update_stack_total_hash(stack_small_id, new_hash).await
-    /// }
-    /// ```
-    #[instrument(
-        level = "trace",
-        skip_all,
-        fields(%stack_small_id, ?new_hash)
-    )]
-    pub async fn update_stack_total_hash(
-        &self,
-        stack_small_id: i64,
-        new_hash: [u8; 32],
-    ) -> Result<()> {
-        let rows_affected = sqlx::query(
-            "UPDATE stacks
-            SET total_hash = total_hash || $1,
-                num_total_messages = num_total_messages + 1
-            WHERE stack_small_id = $2",
-        )
-        .bind(&new_hash[..])
-        .bind(stack_small_id)
-        .execute(&self.db)
-        .await?
-        .rows_affected();
-
-        if rows_affected == 0 {
-            return Err(AtomaStateManagerError::StackNotFound);
-        }
-
-        Ok(())
-    }
-
-    /// Retrieves the total hash for a specific stack.
-    ///
-    /// This method fetches the `total_hash` field from the `stacks` table for the given `stack_small_id`.
-    ///
-    /// # Arguments
-    ///
-    /// * `stack_small_id` - The unique small identifier of the stack whose total hash is to be retrieved.
-    ///
-    /// # Returns
-    ///
-    /// - `Result<Vec<u8>>`: A result containing either:
-    ///   - `Ok(Vec<u8>)`: A byte vector representing the total hash of the stack.
-    ///   - `Err(AtomaStateManagerError)`: An error if the database query fails.
-    ///
-    /// # Errors
-    ///
-    /// This function will return an error if:
-    /// - The database query fails to execute.
-    ///
-    /// # Example
-    ///
-    /// ```rust,ignore
-    /// use atoma_node::atoma_state::AtomaStateManager;
-    ///
-    /// async fn get_total_hash(state_manager: &AtomaStateManager, stack_small_id: i64) -> Result<Vec<u8>, AtomaStateManagerError> {
-    ///     state_manager.get_stack_total_hash(stack_small_id).await
-    /// }
-    /// ```
-    #[instrument(
-        level = "trace",
-        skip_all,
-        fields(%stack_small_id)
-    )]
-    pub async fn get_stack_total_hash(&self, stack_small_id: i64) -> Result<Vec<u8>> {
-        let total_hash = sqlx::query_scalar::<_, Vec<u8>>(
-            "SELECT total_hash FROM stacks WHERE stack_small_id = $1",
-        )
-        .bind(stack_small_id)
-        .fetch_one(&self.db)
-        .await?;
-        Ok(total_hash)
-    }
-
-    /// Retrieves the total hashes for multiple stacks in a single query.
-    ///
-    /// This method efficiently fetches the `total_hash` field from the `stacks` table for all
-    /// provided stack IDs in a single database query.
-    ///
-    /// # Arguments
-    ///
-    /// * `stack_small_ids` - A slice of stack IDs whose total hashes should be retrieved.
-    ///
-    /// # Returns
-    ///
-    /// - `Result<Vec<Vec<u8>>>`: A result containing either:
-    ///   - `Ok(Vec<Vec<u8>>)`: A vector of byte vectors, where each inner vector represents
-    ///     the total hash of a stack. The order corresponds to the order of results returned
-    ///     by the database query.
-    ///   - `Err(AtomaStateManagerError)`: An error if the database query fails.
-    ///
-    /// # Errors
-    ///
-    /// This function will return an error if:
-    /// - The database query fails to execute.
-    /// - There's an issue retrieving the hash data from the result rows.
-    ///
-    /// # Example
-    ///
-    /// ```rust,ignore
-    /// use atoma_node::atoma_state::AtomaStateManager;
-    ///
-    /// async fn get_hashes(state_manager: &AtomaStateManager) -> Result<Vec<Vec<u8>>, AtomaStateManagerError> {
-    ///     let stack_ids = &[1, 2, 3]; // IDs of stacks to fetch hashes for
-    ///     state_manager.get_all_total_hashes(stack_ids).await
-    /// }
-    /// ```
-    #[instrument(
-        level = "trace",
-        skip_all,
-        fields(?stack_small_ids)
-    )]
-    pub async fn get_all_total_hashes(&self, stack_small_ids: &[i64]) -> Result<Vec<Vec<u8>>> {
-        let mut query_builder = build_query_with_in(
-            "SELECT total_hash FROM stacks",
-            "stack_small_id",
-            stack_small_ids,
-            None,
-        );
-
-        Ok(query_builder
-            .build()
-            .fetch_all(&self.db)
-            .await?
-            .iter()
-            .map(|row| row.get("total_hash"))
-            .collect())
     }
 
     /// Updates a stack settlement ticket with attestation commitments.

--- a/atoma-state/src/tests.rs
+++ b/atoma-state/src/tests.rs
@@ -327,7 +327,6 @@ async fn create_test_stack(
                 price_per_one_million_compute_units,
                 already_computed_units,
                 in_settle_period,
-                total_hash,
                 num_total_messages,
                 user_id,
                 acquired_timestamp
@@ -342,7 +341,6 @@ async fn create_test_stack(
     .bind(price)
     .bind(0i64) // Default already_computed_units
     .bind(false) // Default in_settle_period
-    .bind(vec![0u8; 32]) // Default total_hash (32 bytes of zeros)
     .bind(0i64) // Default num_total_messages
     .bind(user_id)
     .bind(chrono::Utc::now()) // Acquired timestamp

--- a/atoma-state/src/tests.rs
+++ b/atoma-state/src/tests.rs
@@ -330,7 +330,7 @@ async fn create_test_stack(
                 num_total_messages,
                 user_id,
                 acquired_timestamp
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)",
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
     )
     .bind(stack_small_id)
     .bind("test_owner") // Default test owner

--- a/atoma-state/src/types.rs
+++ b/atoma-state/src/types.rs
@@ -436,10 +436,6 @@ pub struct Stack {
     /// Indicates whether the stack is currently in the settle period
     pub in_settle_period: bool,
 
-    /// Joint concatenation of Blake2b hashes of each payload and response pairs that was already processed
-    /// by the node for this stack.
-    pub total_hash: Vec<u8>,
-
     /// Number of payload requests that were received by the node for this stack.
     pub num_total_messages: i64,
 }
@@ -457,7 +453,6 @@ impl From<StackCreatedEvent> for Stack {
             already_computed_units: 0,
             locked_compute_units: 0,
             in_settle_period: false,
-            total_hash: vec![],
             num_total_messages: 0,
         }
     }
@@ -595,13 +590,6 @@ pub enum AtomaAtomaStateManagerEvent {
         estimated_total_tokens: i64,
         /// Total number of tokens in the stack
         total_tokens: i64,
-    },
-    /// Represents an update to the total hash of a stack
-    UpdateStackTotalHash {
-        /// Unique small integer identifier for the stack
-        stack_small_id: i64,
-        /// Total hash of the stack
-        total_hash: [u8; 32],
     },
     /// Gets an available stack with enough compute units for a given stack and public key
     GetAvailableStackWithComputeUnits {


### PR DESCRIPTION
This PR drops the unused `total_hash` field which is no longer needed since we are no longer relying on cross validation sampling consensus