### PR TITLE
feat: sends too many requests when we fails communicating with the node

### DIFF
--- a/atoma-proxy/src/server/handlers/chat_completions.rs
+++ b/atoma-proxy/src/server/handlers/chat_completions.rs
@@ -793,9 +793,8 @@ async fn handle_streaming_response(
         .json(&payload)
         .send()
         .await
-        .map_err(|e| AtomaProxyError::InternalError {
+        .map_err(|e| AtomaProxyError::TooManyRequests {
             message: format!("Error sending request to inference service: {e:?}"),
-            client_message: Some("Failed to connect to the node.".to_string()),
             endpoint: endpoint.to_string(),
         })?;
 

--- a/atoma-proxy/src/server/handlers/chat_completions.rs
+++ b/atoma-proxy/src/server/handlers/chat_completions.rs
@@ -596,9 +596,8 @@ async fn handle_non_streaming_response(
         .json(&payload)
         .send()
         .await
-        .map_err(|err| AtomaProxyError::InternalError {
+        .map_err(|err| AtomaProxyError::TooManyRequests {
             message: format!("Failed to send OpenAI API request: {err:?}"),
-            client_message: Some("Failed to connect to the node.".to_string()),
             endpoint: endpoint.to_string(),
         })?;
 


### PR DESCRIPTION
Instead of failing, send too many requests, becuase that's probably what it is.