### PR TITLE
feat: don't create client per request

### DIFF
--- a/atoma-proxy/src/server/handlers/chat_completions.rs
+++ b/atoma-proxy/src/server/handlers/chat_completions.rs
@@ -613,12 +613,12 @@ async fn handle_non_streaming_response(
     endpoint: String,
     model_name: String,
 ) -> Result<Response<Body>> {
-    let client = reqwest::Client::new();
     let time = Instant::now();
 
     let model_label = model_name.clone();
 
-    let response = client
+    let response = state
+        .client
         .post(format!("{node_address}{endpoint}"))
         .headers(headers)
         .json(&payload)
@@ -809,12 +809,12 @@ async fn handle_streaming_response(
     endpoint: String,
     model_name: String,
 ) -> Result<Response<Body>> {
-    let client = reqwest::Client::new();
     let start = Instant::now();
 
     let request_id = uuid::Uuid::new_v4().to_string();
     headers.insert(REQUEST_ID, HeaderValue::from_str(&request_id).unwrap());
-    let response = client
+    let response = state
+        .client
         .post(format!("{node_address}{endpoint}"))
         .headers(headers)
         .json(&payload)
@@ -844,7 +844,7 @@ async fn handle_streaming_response(
     let state_manager_sender = state.state_manager_sender.clone();
     let node_address_clone = node_address.clone();
     let request_id_clone = request_id.clone();
-    let client_clone = client.clone();
+    let client_clone = state.client.clone();
     tokio::spawn(async move {
         tracing::info!(
             target = "atoma-service-chat-completions",

--- a/atoma-proxy/src/server/handlers/completions.rs
+++ b/atoma-proxy/src/server/handlers/completions.rs
@@ -567,12 +567,12 @@ async fn handle_non_streaming_response(
     endpoint: String,
     model_name: String,
 ) -> Result<Response<Body>> {
-    let client = reqwest::Client::new();
     let time = Instant::now();
 
     let model_label = model_name.clone();
 
-    let response = client
+    let response = state
+        .client
         .post(format!("{node_address}{endpoint}"))
         .headers(headers)
         .json(&payload)
@@ -763,12 +763,12 @@ async fn handle_streaming_response(
     endpoint: String,
     model_name: String,
 ) -> Result<Response<Body>> {
-    let client = reqwest::Client::new();
     let start = Instant::now();
 
     let request_id = uuid::Uuid::new_v4().to_string();
     headers.insert(REQUEST_ID, HeaderValue::from_str(&request_id).unwrap());
-    let response = client
+    let response = state
+        .client
         .post(format!("{node_address}{endpoint}"))
         .headers(headers)
         .json(&payload)
@@ -799,7 +799,7 @@ async fn handle_streaming_response(
     let state_manager_sender = state.state_manager_sender.clone();
     let node_address_clone = node_address.clone();
     let request_id_clone = request_id.clone();
-    let client_clone = client.clone();
+    let client_clone = state.client.clone();
     tokio::spawn(async move {
         tracing::info!(
             target = "atoma-service-chat-completions",

--- a/atoma-proxy/src/server/handlers/embeddings.rs
+++ b/atoma-proxy/src/server/handlers/embeddings.rs
@@ -518,10 +518,10 @@ async fn handle_embeddings_response(
     // Record the request in the total failed requests metric
     TEXT_EMBEDDINGS_NUM_REQUESTS.add(1, &[KeyValue::new("model", model_label.clone())]);
 
-    let client = reqwest::Client::new();
     let time = Instant::now();
     // Send the request to the AI node
-    let response = client
+    let response = state
+        .client
         .post(format!("{node_address}{endpoint}"))
         .headers(headers)
         .json(&payload)

--- a/atoma-proxy/src/server/handlers/image_generations.rs
+++ b/atoma-proxy/src/server/handlers/image_generations.rs
@@ -479,7 +479,8 @@ async fn handle_image_generation_response(
 
     let time = Instant::now();
     // Send the request to the AI node
-    let response = state.client
+    let response = state
+        .client
         .post(format!("{node_address}{endpoint}"))
         .headers(headers)
         .json(&payload)

--- a/atoma-proxy/src/server/handlers/image_generations.rs
+++ b/atoma-proxy/src/server/handlers/image_generations.rs
@@ -477,10 +477,9 @@ async fn handle_image_generation_response(
     let model_label: String = model_name.clone();
     IMAGE_GEN_NUM_REQUESTS.add(1, &[KeyValue::new("model", model_label.clone())]);
 
-    let client = reqwest::Client::new();
     let time = Instant::now();
     // Send the request to the AI node
-    let response = client
+    let response = state.client
         .post(format!("{node_address}{endpoint}"))
         .headers(headers)
         .json(&payload)

--- a/atoma-proxy/src/server/http_server.rs
+++ b/atoma-proxy/src/server/http_server.rs
@@ -12,7 +12,7 @@ use axum::{
 };
 use dashmap::DashMap;
 use flume::Sender;
-use reqwest::Method;
+use reqwest::{Client, Method};
 use serde::Serialize;
 use tokenizers::Tokenizer;
 use tokio::sync::watch;
@@ -136,6 +136,9 @@ pub struct ProxyState {
 
     /// Open router models file.
     pub open_router_models_file: String,
+
+    /// HTTP client for making requests.
+    pub client: Client,
 }
 
 #[derive(OpenApi)]
@@ -303,6 +306,7 @@ pub async fn start_server(
         tokenizers: Arc::new(tokenizers),
         models: Arc::new(config.models),
         open_router_models_file: config.open_router_models_file,
+        client: Client::new(),
     };
     let router = create_router(&proxy_state);
     let server =


### PR DESCRIPTION
Don't create client for each request, but pre-create it once for all requests.