### PR TITLE
fix: pinging node causes lock

### DIFF
--- a/atoma-proxy/src/main.rs
+++ b/atoma-proxy/src/main.rs
@@ -183,7 +183,7 @@ async fn main() -> Result<()> {
     .await?;
 
     let state_manager_handle = spawn_with_shutdown(
-        state_manager.run(shutdown_receiver.clone()),
+        state_manager.run(state_manager_sender.clone(), shutdown_receiver.clone()),
         shutdown_sender.clone(),
     );
 

--- a/atoma-state/src/handlers.rs
+++ b/atoma-state/src/handlers.rs
@@ -1468,6 +1468,12 @@ pub async fn handle_state_manager_event(
                     .await?;
             }
         }
+        AtomaAtomaStateManagerEvent::RetrieveNodesPublicAddresses { result_sender } => {
+            let addresses = state_manager.state.retrieve_node_public_addresses().await;
+            result_sender
+                .send(addresses)
+                .map_err(|_| AtomaStateManagerError::ChannelSendError)?;
+        }
     }
     Ok(())
 }

--- a/atoma-state/src/types.rs
+++ b/atoma-state/src/types.rs
@@ -927,4 +927,9 @@ pub enum AtomaAtomaStateManagerEvent {
         /// Number of output tokens
         output_tokens: i64,
     },
+    RetrieveNodesPublicAddresses {
+        /// Channel to send back the list of public addresses
+        /// Returns Ok(Vec<String>) with the list of `public_address` or an error if the query fails
+        result_sender: oneshot::Sender<Result<Vec<String>>>,
+    },
 }


### PR DESCRIPTION
Fixing bad node caused 5sec delay on every DB query. That can cause longer TTFT, timeout on login on website, etc...