### PR TITLE
fix: dockerfile changes for newest sui

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y \
     pkg-config \
     libssl-dev \
     libssl3 \
+    libclang-dev \
     curl \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Add missing `libclang-dev` for newest sui.