### PR TITLE
feat: return too many request on no response from the node

### DIFF
--- a/atoma-proxy/src/server/handlers/completions.rs
+++ b/atoma-proxy/src/server/handlers/completions.rs
@@ -584,9 +584,8 @@ async fn handle_non_streaming_response(
         .json(&payload)
         .send()
         .await
-        .map_err(|err| AtomaProxyError::InternalError {
+        .map_err(|err| AtomaProxyError::TooManyRequests {
             message: format!("Failed to send OpenAI API request: {err:?}"),
-            client_message: Some("Failed to connect to the node.".to_string()),
             endpoint: endpoint.to_string(),
         })?;
 
@@ -783,9 +782,8 @@ async fn handle_streaming_response(
         .json(&payload)
         .send()
         .await
-        .map_err(|e| AtomaProxyError::InternalError {
+        .map_err(|e| AtomaProxyError::TooManyRequests {
             message: format!("Error sending request to inference service: {e:?}"),
-            client_message: Some("Failed to connect to the node.".to_string()),
             endpoint: endpoint.to_string(),
         })?;
 


### PR DESCRIPTION
Return http code 429 (too many request) when there is error in sending request to the node.