### PR TITLE
feat: forbid stacks

### DIFF
--- a/atoma-proxy/src/server/error.rs
+++ b/atoma-proxy/src/server/error.rs
@@ -213,7 +213,7 @@ impl AtomaProxyError {
     /// An [`axum::http::StatusCode`] representing the appropriate HTTP response code for this error
     pub const fn status_code(&self) -> StatusCode {
         match self {
-            Self::RequestError { .. } => StatusCode::BAD_REQUEST,
+            Self::FiatPaymentsOnly { .. } | Self::RequestError { .. } => StatusCode::BAD_REQUEST,
             Self::AuthError { .. } => StatusCode::UNAUTHORIZED,
             Self::InternalError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             Self::NotFound { .. } => StatusCode::NOT_FOUND,
@@ -223,7 +223,6 @@ impl AtomaProxyError {
             Self::Locked { .. } => StatusCode::LOCKED,
             Self::UnavailableStack { .. } => StatusCode::TOO_EARLY,
             Self::TooManyRequests { .. } => StatusCode::TOO_MANY_REQUESTS,
-            Self::FiatPaymentsOnly { .. } => StatusCode::BAD_REQUEST,
         }
     }
 
@@ -278,9 +277,7 @@ impl AtomaProxyError {
             Self::Locked { message, .. } => format!("Locked: {message}"),
             Self::UnavailableStack { message, .. } => format!("Stack unavailable: {message}"),
             Self::TooManyRequests { message, .. } => format!("Too many requests: {message}"),
-            Self::FiatPaymentsOnly { .. } => {
-                format!("Only fiat payments are supported")
-            }
+            Self::FiatPaymentsOnly { .. } => "Only fiat payments are supported".to_string(),
         }
     }
 }

--- a/atoma-proxy/src/server/error.rs
+++ b/atoma-proxy/src/server/error.rs
@@ -164,6 +164,7 @@ impl AtomaProxyError {
             Self::Locked { .. } => "LOCKED",
             Self::UnavailableStack { .. } => "UNAVAILABLE_STACK",
             Self::TooManyRequests { .. } => "TOO_MANY_REQUESTS",
+            Self::FiatPaymentsOnly { .. } => "FIAT_PAYMENTS_ONLY",
         }
     }
 
@@ -196,6 +197,7 @@ impl AtomaProxyError {
             Self::Locked { .. } => "Locked".to_string(),
             Self::UnavailableStack { .. } => "Stack unavailable".to_string(),
             Self::TooManyRequests { .. } => "Too many requests".to_string(),
+            Self::FiatPaymentsOnly { .. } => "Only fiat payments are supported".to_string(),
         }
     }
 
@@ -221,6 +223,7 @@ impl AtomaProxyError {
             Self::Locked { .. } => StatusCode::LOCKED,
             Self::UnavailableStack { .. } => StatusCode::TOO_EARLY,
             Self::TooManyRequests { .. } => StatusCode::TOO_MANY_REQUESTS,
+            Self::FiatPaymentsOnly { .. } => StatusCode::BAD_REQUEST,
         }
     }
 
@@ -243,7 +246,8 @@ impl AtomaProxyError {
             | Self::BalanceError { endpoint, .. }
             | Self::Locked { endpoint, .. }
             | Self::UnavailableStack { endpoint, .. }
-            | Self::TooManyRequests { endpoint, .. } => endpoint.clone(),
+            | Self::TooManyRequests { endpoint, .. }
+            | Self::FiatPaymentsOnly { endpoint, .. } => endpoint.clone(),
         }
     }
 
@@ -274,6 +278,9 @@ impl AtomaProxyError {
             Self::Locked { message, .. } => format!("Locked: {message}"),
             Self::UnavailableStack { message, .. } => format!("Stack unavailable: {message}"),
             Self::TooManyRequests { message, .. } => format!("Too many requests: {message}"),
+            Self::FiatPaymentsOnly { .. } => {
+                format!("Only fiat payments are supported")
+            }
         }
     }
 }

--- a/atoma-proxy/src/server/error.rs
+++ b/atoma-proxy/src/server/error.rs
@@ -126,6 +126,14 @@ pub enum AtomaProxyError {
         /// The endpoint that the error occurred on
         endpoint: String,
     },
+
+    #[error("Only fiat payments are supported")]
+    FiatPaymentsOnly {
+        /// Description of the fiat payments only error
+        message: String,
+        /// The endpoint that the error occurred on
+        endpoint: String,
+    },
 }
 
 impl AtomaProxyError {

--- a/atoma-proxy/src/server/middleware.rs
+++ b/atoma-proxy/src/server/middleware.rs
@@ -1363,33 +1363,9 @@ pub mod auth {
                 is_fiat_request: true,
             });
         }
-
-        let optional_stack = send_event_with_response(
-            &state.state_manager_sender,
-            |result_sender| {
-                AtomaAtomaStateManagerEvent::GetStacksForModel {
-                    model: model.to_string(),
-                    free_compute_units: (num_input_tokens + max_output_tokens) as i64,
-                    user_id,
-                    is_confidential: false, // NOTE: This method is only used for non-confidential compute
-                    result_sender,
-                }
-            },
-            "GetStacksForModel",
-            endpoint,
-        )
-        .await?;
-
-        Ok(StackMetadata {
-            optional_stack,
-            num_input_tokens,
-            max_output_tokens,
-            model,
-            user_id,
-            selected_node_id: node.node_small_id,
-            price_per_one_million_input_compute_units,
-            price_per_one_million_output_compute_units,
-            is_fiat_request: false,
+        Err(AtomaProxyError::FiatPaymentsOnly {
+            message: "Fiat payments only, no stacks available".to_string(),
+            endpoint: endpoint.to_string(),
         })
     }
 


### PR DESCRIPTION
This pull request introduces a new error type to handle fiat payment restrictions and updates the middleware logic to enforce this restriction. The changes focus on improving error handling and simplifying the logic for unsupported payment methods.

### Error Handling Improvements:
* Added a new error variant `FiatPaymentsOnly` to the `AtomaProxyError` enum in `atoma-proxy/src/server/error.rs`. This error includes a message and endpoint details to provide more specific feedback when only fiat payments are supported.

### Middleware Logic Updates:
* Removed the logic for retrieving stacks for a model in `atoma-proxy/src/server/middleware.rs` and replaced it with an error response using the newly added `FiatPaymentsOnly` error. This simplifies the code path for scenarios where fiat payments are enforced.