### PR TITLE
fix: cargo deny check

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -26,8 +26,10 @@ ignore = [
     "RUSTSEC-2024-0437",
     # paste is unmaintained
     "RUSTSEC-2024-0436",
-    # openssl v0.10.71 is required by sui-sdk
-    "RUSTSEC-2025-0022",
+    # backoff is unmaintned, essentially used by sui-sdk
+    "RUSTSEC-2025-0012",
+    # backoff is unmaintned, used by the backoff above
+    "RUSTSEC-2024-0384"
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/deny.toml
+++ b/deny.toml
@@ -29,7 +29,7 @@ ignore = [
     # backoff is unmaintned, essentially used by sui-sdk
     "RUSTSEC-2025-0012",
     # backoff is unmaintned, used by the backoff above
-    "RUSTSEC-2024-0384"
+    "RUSTSEC-2024-0384",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
Fix cargo deny by adding ignore RUSTSEC into the deny.toml. Removed unusued ignored RUSTSEC