### PR TITLE
fix: coverage CI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,7 +43,7 @@ jobs:
         run: cargo install cargo-llvm-cov
 
       - name: Generate coverage
-        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info --jobs 1 -- --test-threads=1
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info --jobs 1
       - name: Upload to Codecov
         uses: codecov/codecov-action@v5
         with:


### PR DESCRIPTION
Fix the coverage CI by limiting the jobs to 1, anything more than one causes OOM on the CI, because it's limited by 7GB memory.